### PR TITLE
chore: 统一依赖安装，npm install 一键完成

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,13 +73,7 @@ ui.user_input → agent.step_started → llm.call_requested → llm.call_complet
 git clone https://github.com/SenseTime-FVG/agentos.git
 cd agentos
 
-# Python 依赖
-uv sync          # 或 pip install -e .
-
-# 前端依赖
-cd agentos/app/web && npm install && cd -
-
-# 根目录 Playwright（可选，用于前端 e2e 测试）
+# 一键安装所有依赖（Python + 前端 + Playwright）
 npm install
 ```
 

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "private": true,
   "version": "0.5.0",
   "scripts": {
+    "postinstall": "bash ./scripts/postinstall.sh",
     "dev": "bash ./scripts/dev.sh",
     "dev:server": "python3 -m uvicorn agentos.app.gateway.main:app --reload --host 0.0.0.0 --port 8000",
     "dev:web": "cd agentos/app/web && npm run dev",

--- a/scripts/postinstall.sh
+++ b/scripts/postinstall.sh
@@ -1,0 +1,59 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m'
+
+ROOT_DIR="$(cd "$(dirname "$0")/.." && pwd)"
+MISSING=()
+
+# 检查 uv
+if ! command -v uv >/dev/null 2>&1; then
+  MISSING+=("uv")
+fi
+
+# 检查 npm（子目录安装需要）
+if ! command -v npm >/dev/null 2>&1; then
+  MISSING+=("npm")
+fi
+
+if [ ${#MISSING[@]} -gt 0 ]; then
+  echo ""
+  echo -e "${RED}✗ 缺少必要的工具: ${MISSING[*]}${NC}"
+  echo ""
+  echo "请按以下指南安装："
+  echo ""
+  for tool in "${MISSING[@]}"; do
+    case "$tool" in
+      uv)
+        echo -e "  ${YELLOW}uv${NC} (Python 包管理器):"
+        echo "    curl -LsSf https://astral.sh/uv/install.sh | sh"
+        echo "    详见: https://docs.astral.sh/uv/getting-started/installation/"
+        echo ""
+        ;;
+      npm)
+        echo -e "  ${YELLOW}npm${NC} (Node.js 包管理器):"
+        echo "    安装 Node.js (>= 18): https://nodejs.org/"
+        echo "    或使用 nvm: curl -o- https://raw.githubusercontent.com/nvm-sh/nvm/v0.40.1/install.sh | bash"
+        echo ""
+        ;;
+    esac
+  done
+  echo -e "安装完成后重新运行 ${GREEN}npm install${NC}"
+  exit 1
+fi
+
+echo ""
+echo -e "${GREEN}▶ 安装 Python 依赖...${NC}"
+cd "$ROOT_DIR"
+uv sync
+
+echo ""
+echo -e "${GREEN}▶ 安装前端依赖...${NC}"
+cd "$ROOT_DIR/agentos/app/web"
+npm install
+
+echo ""
+echo -e "${GREEN}✔ 所有依赖安装完成${NC}"


### PR DESCRIPTION
## Summary
- 新增 `scripts/postinstall.sh`，在 `npm install` 后自动执行 `uv sync` 和前端 `npm install`
- 脚本检查环境是否有 `uv` 和 `npm`，缺少时输出彩色安装指南并退出
- 简化 README 安装步骤：三条命令合并为一条 `npm install`

## Test plan
- [ ] 在有 uv + npm 的环境下执行 `npm install`，确认 Python 依赖和前端依赖都正确安装
- [ ] 在无 uv 的环境下执行 `npm install`，确认输出安装指引并以非零状态退出

Made with [Cursor](https://cursor.com)