### PR TITLE
feat: CLI 统一入口 + 命令扩展 + 交互体验优化

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,18 +16,24 @@ AgentOS 是基于事件驱动架构的 AI Agent 平台，支持 Web、CLI、TUI 
 ### 开发启动
 
 ```bash
-# 一键启动前后端（推荐）
-npm run dev
+# 一键启动后端 + 前端 dashboard（推荐）
+agentos run
+# 或: npm run dev  /  python3 -m agentos.app.main run
 
-# 单独启动后端
-npm run dev:server
-# 或: python3 -m uvicorn agentos.app.gateway.main:app --reload --host 0.0.0.0 --port 8000
+# 仅启动后端
+agentos run --no-frontend
+# 或: npm run dev:server
 
 # 单独启动前端
 npm run dev:web
 
-# 启动 TUI 客户端（需后端已运行）
-python3 -m agentos.app.cli.cli_client --port 8000
+# 启动 CLI 客户端（需后端已运行）
+agentos cli
+# 或: python3 -m agentos.app.main cli --port 8000
+
+# 自定义端口
+agentos run --port 9000 --frontend-port 3001
+agentos cli --port 9000
 ```
 
 ### 测试

--- a/agentos/app/cli/app.py
+++ b/agentos/app/cli/app.py
@@ -1,10 +1,13 @@
-"""CLIApp 主类 + WebSocket 管理 + 主循环"""
+"""CLIApp 主类 + WebSocket 管理 + HTTP 客户端 + 主循环"""
 
 from __future__ import annotations
 
 import asyncio
 import json
+import signal
 import sys
+import urllib.request
+import urllib.error
 
 import websockets
 from rich.console import Console
@@ -38,8 +41,11 @@ class CLIApp:
         self.current_agent_id: str = agent_id or "default"
 
         self._waiting = asyncio.Event()
+        self._query_event = asyncio.Event()  # 查询命令响应完成信号
         self._confirm_queue: asyncio.Queue[dict] = asyncio.Queue()
         self._last_response: str = ""
+        self._turn_cancelled = False
+        self._recv_loop_running = False
 
         self.console = Console()
         self.dispatcher = CommandDispatcher(self)
@@ -67,6 +73,7 @@ class CLIApp:
 
     async def _receive_loop(self) -> None:
         """接收 WebSocket 消息的后台循环"""
+        self._recv_loop_running = True
         async for raw in self.ws:
             data = json.loads(raw)
             msg_type = data.get("type", "")
@@ -84,52 +91,141 @@ class CLIApp:
                     self._last_response = data.get("payload", {}).get("final_response", "")
                     self.display.show_response(self._last_response)
                 else:
-                    self.display.show_error(data)
+                    # 用户主动取消时，静默吞掉后端的 cancel error
+                    if not self._turn_cancelled:
+                        self.display.show_error(data)
                 self._waiting.set()
                 continue
 
             self.display.handle_event(data)
 
+            # 查询/会话类响应：通知等待方
+            if msg_type in (
+                "sessions_list", "agents_list", "messages_list",
+                "session_deleted", "session_renamed",
+                "session_created", "session_loaded",
+            ):
+                self._query_event.set()
+
     async def _wait_for_turn(self) -> None:
-        """等待 turn 完成，期间处理确认请求"""
-        while True:
-            self._waiting.clear()
-            await self._waiting.wait()
+        """等待 turn 完成，期间处理确认请求。"""
+        self.display.spinner.start()
+        try:
+            while True:
+                self._waiting.clear()
+                await self._waiting.wait()
 
-            while not self._confirm_queue.empty():
-                confirm_data = await self._confirm_queue.get()
-                if self.execute:
-                    approved = False  # 脚本模式自动拒绝
-                else:
-                    approved = await self.display.prompt_confirmation(confirm_data)
-                await self._send_confirmation_response(confirm_data, approved)
-                continue
+                while not self._confirm_queue.empty():
+                    confirm_data = await self._confirm_queue.get()
+                    self.display.spinner.stop()
+                    if self.execute:
+                        approved = False
+                    else:
+                        approved = await self.display.prompt_confirmation(confirm_data)
+                    await self._send_confirmation_response(confirm_data, approved)
+                    self.display.spinner.start()
+                    continue
 
-            if self._confirm_queue.empty():
-                break
+                if self._confirm_queue.empty():
+                    break
+        finally:
+            self.display.spinner.stop()
+
+    async def _cancel_current_turn(self) -> None:
+        """发送取消请求并中止当前等待"""
+        self._turn_cancelled = True
+        await self._send({
+            "type": "cancel_turn",
+            "session_id": self.current_session_id,
+            "payload": {"reason": "user_cancel"},
+        })
+        self.display.show_cancelled()
+        self._waiting.set()
 
     async def _send(self, msg: dict) -> None:
         """发送 JSON 消息到 WebSocket"""
         await self.ws.send(json.dumps(msg))
 
+    async def _send_query(self, msg: dict, timeout: float = 5.0) -> None:
+        """发送查询命令并等待响应到达后再返回"""
+        self._query_event.clear()
+        await self._send(msg)
+        try:
+            await asyncio.wait_for(self._query_event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            pass  # 超时就继续，不阻塞
+
+    # ── HTTP 客户端辅助 ──────────────────────────────
+
+    @property
+    def _base_url(self) -> str:
+        return f"http://{self.host}:{self.port}"
+
+    async def _http(self, method: str, path: str, body: dict | None = None) -> dict:
+        """发送 HTTP 请求到后端 REST API，返回 JSON 响应"""
+        url = f"{self._base_url}{path}"
+        data = json.dumps(body).encode() if body is not None else None
+        req = urllib.request.Request(
+            url, data=data, method=method,
+            headers={"Content-Type": "application/json"} if data else {},
+        )
+        try:
+            resp = await asyncio.to_thread(urllib.request.urlopen, req, timeout=10)
+            return json.loads(resp.read().decode())
+        except urllib.error.HTTPError as e:
+            err_body = e.read().decode() if e.fp else ""
+            try:
+                detail = json.loads(err_body).get("detail", err_body)
+            except (json.JSONDecodeError, AttributeError):
+                detail = err_body
+            return {"_error": True, "status": e.code, "detail": detail}
+        except Exception as e:
+            return {"_error": True, "status": 0, "detail": str(e)}
+
+    async def _http_get(self, path: str) -> dict:
+        return await self._http("GET", path)
+
+    async def _http_post(self, path: str, body: dict | None = None) -> dict:
+        return await self._http("POST", path, body)
+
+    async def _http_put(self, path: str, body: dict | None = None) -> dict:
+        return await self._http("PUT", path, body)
+
+    async def _http_delete(self, path: str) -> dict:
+        return await self._http("DELETE", path)
+
+    async def _fetch_agent_info(self, agent_id: str) -> dict:
+        """获取 Agent 信息（名称、工作目录等），失败时返回空 dict"""
+        resp = await self._http_get(f"/api/agents/{agent_id}")
+        if isinstance(resp, dict) and not resp.get("_error"):
+            return resp
+        return {}
+
     async def _create_session(self, agent_id: str | None = None) -> str:
-        """创建新会话"""
-        await self._send({
-            "type": "create_session",
-            "payload": {"agent_id": agent_id or "default"},
-        })
-        resp = json.loads(await self.ws.recv())
-        self.current_session_id = resp.get("session_id")
+        """创建新会话。_receive_loop 运行前直接 recv，运行后走 _query_event。"""
+        msg = {"type": "create_session", "payload": {"agent_id": agent_id or "default"}}
+        if self._recv_loop_running:
+            self._query_event.clear()
+            await self._send(msg)
+            try:
+                await asyncio.wait_for(self._query_event.wait(), timeout=5.0)
+            except asyncio.TimeoutError:
+                pass
+        else:
+            await self._send(msg)
+            resp = json.loads(await self.ws.recv())
+            self.current_session_id = resp.get("session_id")
         self.current_agent_id = agent_id or "default"
         return self.current_session_id
 
     async def _load_session(self, session_id: str) -> None:
-        """加载已有会话"""
-        await self._send({
-            "type": "load_session",
-            "payload": {"session_id": session_id},
-        })
-        await self.ws.recv()
+        """加载已有会话。_receive_loop 运行前直接 recv，运行后走 _query_event。"""
+        msg = {"type": "load_session", "payload": {"session_id": session_id}}
+        if self._recv_loop_running:
+            await self._send_query(msg)
+        else:
+            await self._send(msg)
+            await self.ws.recv()
         self.current_session_id = session_id
 
     async def _send_user_input(self, content: str) -> None:
@@ -165,7 +261,22 @@ class CLIApp:
 
     async def _run_interactive_mode(self) -> int:
         """交互模式：REPL 循环"""
-        self.display.show_welcome()
+        # 获取 Agent 信息用于欢迎页
+        agent_info = await self._fetch_agent_info(self.current_agent_id)
+        agent_name = agent_info.get("name", "")
+        # 构造工作目录显示
+        workdir = ""
+        if agent_info.get("id"):
+            # 从后端获取 agentos_home 拼接 workdir 路径
+            try:
+                from pathlib import Path
+                home = Path.home() / ".agentos"
+                workdir = str(home / "workdir" / agent_info["id"])
+            except Exception:
+                pass
+
+        self.display.show_welcome(agent_name=agent_name, workdir=workdir)
+
         while True:
             try:
                 raw = await asyncio.to_thread(read_user_input)
@@ -184,4 +295,23 @@ class CLIApp:
                 continue
 
             await self._send_user_input(text)
-            await self._wait_for_turn()
+
+            # 等待回复，Ctrl+C 中止当前对话而非退出程序
+            self._turn_cancelled = False
+            wait_task = asyncio.create_task(self._wait_for_turn())
+            loop = asyncio.get_event_loop()
+
+            def _on_sigint():
+                self._turn_cancelled = True
+                if not wait_task.done():
+                    wait_task.cancel()
+
+            loop.add_signal_handler(signal.SIGINT, _on_sigint)
+            try:
+                await wait_task
+            except asyncio.CancelledError:
+                # 先发送取消、显示提示，再等后端 error 到达并被静默吞掉
+                await self._cancel_current_turn()
+                await asyncio.sleep(0.3)
+            finally:
+                loop.remove_signal_handler(signal.SIGINT)

--- a/agentos/app/cli/commands.py
+++ b/agentos/app/cli/commands.py
@@ -2,10 +2,50 @@
 
 from __future__ import annotations
 
+import json
 from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from agentos.app.cli.app import CLIApp
+
+
+# ── Tab 补全定义 ──────────────────────────────────────
+
+# 顶层命令
+TOP_COMMANDS = [
+    "/new", "/session", "/agent", "/tool", "/skill",
+    "/history", "/debug", "/help", "/quit",
+]
+
+# 子命令映射
+SUB_COMMANDS: dict[str, list[str]] = {
+    "/session": ["list", "switch", "current"],
+    "/agent":   ["list", "create", "delete", "info", "switch", "config"],
+    "/tool":    ["list", "enable", "disable"],
+    "/skill":   ["list", "search", "enable", "disable"],
+    "/debug":   ["on", "off"],
+}
+
+
+def get_completions(buffer: str) -> list[str]:
+    """根据当前输入返回可用的补全项"""
+    text = buffer.rstrip()
+    has_space = buffer != buffer.rstrip()  # 末尾有空格
+    if not text or text == "/":
+        return TOP_COMMANDS
+
+    # 已输入空格 → 进入子命令补全
+    if has_space or " " in text:
+        parts = text.split(maxsplit=1)
+        cmd = parts[0].lower()
+        partial = parts[1] if len(parts) > 1 else ""
+        subs = SUB_COMMANDS.get(cmd, [])
+        if not partial:
+            return subs
+        return [s for s in subs if s.startswith(partial)]
+
+    # 匹配顶层命令前缀（如 "/se" → ["/session", "/skill"]）
+    return [c for c in TOP_COMMANDS if c.startswith(text)]
 
 
 class CommandDispatcher:
@@ -16,30 +56,41 @@ class CommandDispatcher:
 
     async def dispatch(self, raw: str) -> str | None:
         """分派命令，返回 "quit" 表示退出"""
-        parts = raw.strip().split(maxsplit=1)
+        parts = raw.strip().split(maxsplit=2)
         cmd = parts[0].lower()
         arg = parts[1] if len(parts) > 1 else ""
+        arg2 = parts[2] if len(parts) > 2 else ""
 
         if cmd == "/quit":
             return "quit"
         if cmd in ("/help", "/"):
             self._show_help()
+
+        # ── 会话管理 ──────────────────────────────
         elif cmd == "/new":
             sid = await self.app._create_session(arg.strip() or None)
             self.app.console.print(f"[green]✓ 新会话: {sid} (Agent: {arg or 'default'})[/green]")
-        elif cmd in ("/sessions", "/ls"):
-            await self.app._send({"type": "list_sessions", "payload": {}})
-        elif cmd in ("/switch", "/sw"):
-            if not arg:
-                self.app.console.print("[red]用法: /switch <session_id>[/red]")
-            else:
-                await self.app._load_session(arg.strip())
-                self.app.console.print(f"[green]✓ 已切换到 {arg.strip()}[/green]")
+        elif cmd == "/session":
+            await self._handle_session(arg.strip(), arg2.strip())
         elif cmd in ("/history", "/h"):
-            await self.app._send({
+            await self.app._send_query({
                 "type": "get_messages",
                 "payload": {"session_id": self.app.current_session_id},
             })
+
+        # ── Agent 管理 ──────────────────────────────
+        elif cmd == "/agent":
+            await self._handle_agent(arg.strip(), arg2.strip(), raw)
+
+        # ── 工具管理 ──────────────────────────────
+        elif cmd == "/tool":
+            await self._handle_tool(arg.strip(), arg2.strip())
+
+        # ── 技能管理 ──────────────────────────────
+        elif cmd == "/skill":
+            await self._handle_skill(arg.strip(), arg2.strip())
+
+        # ── 系统 ──────────────────────────────
         elif cmd == "/debug":
             if arg.lower() == "on":
                 self.app.debug = True
@@ -49,41 +100,287 @@ class CommandDispatcher:
                 self.app.console.print("[cyan]调试模式已关闭[/cyan]")
             else:
                 self.app.console.print(f"[cyan]调试模式: {'开启' if self.app.debug else '关闭'}[/cyan]")
-        elif cmd == "/agents":
-            await self.app._send({"type": "list_agents", "payload": {}})
-        elif cmd == "/cancel":
-            await self.app._send({
-                "type": "cancel_turn",
-                "session_id": self.app.current_session_id,
-                "payload": {"reason": "user_cancel"},
-            })
-            self.app.console.print("[yellow]已请求取消当前轮次[/yellow]")
-        elif cmd == "/current":
-            self.app.console.print(f"会话: {self.app.current_session_id}")
-            self.app.console.print(f"Agent: {self.app.current_agent_id}")
-            self.app.console.print(f"调试: {'开启' if self.app.debug else '关闭'}")
         else:
             self.app.console.print(f"[yellow]未知命令: {cmd}[/yellow]")
             self._show_help()
         return None
+
+    # ── Session 子命令 ──────────────────────────────
+
+    async def _handle_session(self, subcmd: str, rest: str) -> None:
+        """处理 /session <subcmd> ..."""
+        if subcmd in ("", "list", "ls"):
+            await self.app._send_query({"type": "list_sessions", "payload": {}})
+        elif subcmd in ("switch", "sw"):
+            if not rest:
+                self.app.console.print("[red]用法: /session switch <session_id>[/red]")
+            else:
+                await self.app._load_session(rest.strip())
+                self.app.console.print(f"[green]✓ 已切换到 {rest.strip()}[/green]")
+        elif subcmd == "current":
+            self.app.console.print(f"会话: {self.app.current_session_id}")
+            self.app.console.print(f"Agent: {self.app.current_agent_id}")
+            self.app.console.print(f"调试: {'开启' if self.app.debug else '关闭'}")
+        else:
+            self.app.console.print("""[cyan]Session 子命令:[/cyan]
+  /session list                 列出历史会话
+  /session switch <id>          切换会话
+  /session current              当前会话信息""")
+
+    # ── Agent 子命令 ──────────────────────────────
+
+    async def _handle_agent(self, subcmd: str, rest: str, raw: str) -> None:
+        """处理 /agent <subcmd> ..."""
+        if subcmd in ("", "list", "ls"):
+            await self.app._send_query({"type": "list_agents", "payload": {}})
+        elif subcmd == "create":
+            await self._agent_create(raw)
+        elif subcmd == "delete":
+            await self._agent_delete(rest)
+        elif subcmd == "info":
+            await self._agent_info(rest)
+        elif subcmd in ("switch", "use"):
+            await self._agent_switch(rest)
+        elif subcmd == "config":
+            await self._agent_config(rest, raw)
+        else:
+            self.app.console.print("""[cyan]Agent 子命令:[/cyan]
+  /agent list                       列出可用 Agent
+  /agent create <id> <name>         创建 Agent
+  /agent delete <id>                删除 Agent
+  /agent info [id]                  查看 Agent 详情
+  /agent switch <id>                切换 Agent（创建新会话）
+  /agent config <id> <key> <value>  修改 Agent 配置""")
+
+    async def _agent_create(self, raw: str) -> None:
+        """创建 Agent: /agent create <id> <name>"""
+        parts = raw.strip().split(maxsplit=3)
+        if len(parts) < 4:
+            self.app.console.print("[red]用法: /agent create <id> <name>[/red]")
+            return
+        agent_id = parts[2]
+        name = parts[3]
+        resp = await self.app._http_post("/api/agents", {"id": agent_id, "name": name})
+        if resp.get("_error"):
+            self.app.console.print(f"[red]创建失败: {resp.get('detail')}[/red]")
+        else:
+            self.app.console.print(f"[green]✓ Agent 已创建: {resp.get('id')} ({resp.get('model', '')})[/green]")
+
+    async def _agent_delete(self, agent_id: str) -> None:
+        if not agent_id:
+            self.app.console.print("[red]用法: /agent delete <id>[/red]")
+            return
+        resp = await self.app._http_delete(f"/api/agents/{agent_id}")
+        if resp.get("_error"):
+            self.app.console.print(f"[red]删除失败: {resp.get('detail')}[/red]")
+        else:
+            self.app.console.print(f"[green]✓ Agent 已删除: {agent_id}[/green]")
+
+    async def _agent_info(self, agent_id: str) -> None:
+        agent_id = agent_id or self.app.current_agent_id
+        resp = await self.app._http_get(f"/api/agents/{agent_id}")
+        if resp.get("_error"):
+            self.app.console.print(f"[red]查询失败: {resp.get('detail')}[/red]")
+            return
+        self.app.console.print(f"\n[bold]{resp.get('id')}[/bold] - {resp.get('name', '')}")
+        self.app.console.print(f"  描述: {resp.get('description', '-')}")
+        self.app.console.print(f"  Provider: {resp.get('provider', '-')}  Model: {resp.get('model', '-')}")
+        self.app.console.print(f"  Temperature: {resp.get('temperature', '-')}  MaxTokens: {resp.get('maxTokens', '-')}")
+        self.app.console.print(f"  工具: {resp.get('toolCount', 0)} 个  技能: {resp.get('skillCount', 0)} 个")
+        self.app.console.print(f"  会话数: {resp.get('sessionCount', 0)}")
+        tools = resp.get("tools", [])
+        if tools:
+            self.app.console.print(f"  工具列表: {', '.join(tools[:10])}")
+        skills = resp.get("skills", [])
+        if skills:
+            self.app.console.print(f"  技能列表: {', '.join(skills[:10])}")
+        self.app.console.print()
+
+    async def _agent_switch(self, agent_id: str) -> None:
+        if not agent_id:
+            self.app.console.print("[red]用法: /agent switch <id>[/red]")
+            return
+        resp = await self.app._http_get(f"/api/agents/{agent_id}")
+        if resp.get("_error"):
+            self.app.console.print(f"[red]Agent 不存在: {agent_id}[/red]")
+            return
+        sid = await self.app._create_session(agent_id)
+        self.app.console.print(f"[green]✓ 已切换到 Agent: {agent_id}  新会话: {sid}[/green]")
+
+    async def _agent_config(self, rest: str, raw: str) -> None:
+        """修改 Agent 配置: /agent config <id> <key> <value>"""
+        parts = raw.strip().split(maxsplit=4)
+        if len(parts) < 5:
+            self.app.console.print("[red]用法: /agent config <id> <key> <value>[/red]")
+            self.app.console.print("[dim]可用 key: name, description, provider, model, temperature, systemPrompt[/dim]")
+            return
+        agent_id = parts[2]
+        key = parts[3]
+        value = parts[4]
+        if key == "temperature":
+            try:
+                value = float(value)
+            except ValueError:
+                self.app.console.print("[red]temperature 需要是数字[/red]")
+                return
+        elif key == "max_tokens":
+            try:
+                value = int(value)
+            except ValueError:
+                self.app.console.print("[red]max_tokens 需要是整数[/red]")
+                return
+        resp = await self.app._http_put(f"/api/agents/{agent_id}/config", {key: value})
+        if resp.get("_error"):
+            self.app.console.print(f"[red]更新失败: {resp.get('detail')}[/red]")
+        else:
+            self.app.console.print(f"[green]✓ {agent_id}.{key} 已更新[/green]")
+
+    # ── 工具子命令 ──────────────────────────────
+
+    async def _handle_tool(self, subcmd: str, tool_name: str) -> None:
+        if subcmd in ("", "list", "ls"):
+            await self._tools_list()
+        elif subcmd == "enable" and tool_name:
+            resp = await self.app._http_put(f"/api/tools/{tool_name}/enabled", {"enabled": True})
+            if isinstance(resp, dict) and resp.get("_error"):
+                self.app.console.print(f"[red]启用失败: {resp.get('detail')}[/red]")
+            else:
+                self.app.console.print(f"[green]✓ {tool_name} 已启用[/green]")
+        elif subcmd == "disable" and tool_name:
+            resp = await self.app._http_put(f"/api/tools/{tool_name}/enabled", {"enabled": False})
+            if isinstance(resp, dict) and resp.get("_error"):
+                self.app.console.print(f"[red]禁用失败: {resp.get('detail')}[/red]")
+            else:
+                self.app.console.print(f"[yellow]✓ {tool_name} 已禁用[/yellow]")
+        else:
+            self.app.console.print("""[cyan]工具子命令:[/cyan]
+  /tool list                    列出所有工具
+  /tool enable <name>           启用工具
+  /tool disable <name>          禁用工具""")
+
+    async def _tools_list(self) -> None:
+        resp = await self.app._http_get("/api/tools")
+        if isinstance(resp, dict) and resp.get("_error"):
+            self.app.console.print(f"[red]获取失败: {resp.get('detail')}[/red]")
+            return
+        tools = resp if isinstance(resp, list) else []
+        if not tools:
+            self.app.console.print("[dim]暂无工具[/dim]")
+            return
+        self.app.console.print(f"\n[bold]已注册工具[/bold] ({len(tools)} 个)\n")
+        for t in tools:
+            status = "[green]✓[/green]" if t.get("enabled", True) else "[red]✗[/red]"
+            risk = t.get("riskLevel", "low")
+            desc = (t.get("description") or "")[:50]
+            self.app.console.print(f"  {status} {t['name']:20s}  {risk:6s}  {desc}")
+        self.app.console.print()
+
+    # ── 技能子命令 ──────────────────────────────
+
+    async def _handle_skill(self, subcmd: str, query: str) -> None:
+        if subcmd in ("", "list", "ls"):
+            await self._skills_list()
+        elif subcmd == "search" and query:
+            resp = await self.app._http_get(f"/api/skills/search?q={urllib_quote(query)}")
+            if isinstance(resp, dict) and resp.get("_error"):
+                self.app.console.print(f"[red]搜索失败: {resp.get('detail')}[/red]")
+                return
+            local = resp.get("local_results", [])
+            remote = resp.get("remote_results", [])
+            if local:
+                self.app.console.print(f"\n[bold]本地匹配[/bold] ({len(local)} 个)")
+                for s in local:
+                    self.app.console.print(f"  {s['name']:24s}  {s.get('description', '')[:40]}")
+            if remote:
+                self.app.console.print(f"\n[bold]市场结果[/bold] ({len(remote)} 个)")
+                for s in remote:
+                    installed = " [green](已安装)[/green]" if s.get("installed") else ""
+                    self.app.console.print(f"  {s['name']:24s}  {s.get('source', ''):10s}  {s.get('description', '')[:30]}{installed}")
+            if not local and not remote:
+                self.app.console.print(f"[dim]未找到匹配: {query}[/dim]")
+            self.app.console.print()
+        elif subcmd == "enable" and query:
+            resp = await self.app._http(
+                "PATCH", f"/api/skills/{query}", {"enabled": True}
+            )
+            if isinstance(resp, dict) and resp.get("_error"):
+                self.app.console.print(f"[red]启用失败: {resp.get('detail')}[/red]")
+            else:
+                self.app.console.print(f"[green]✓ {query} 已启用[/green]")
+        elif subcmd == "disable" and query:
+            resp = await self.app._http(
+                "PATCH", f"/api/skills/{query}", {"enabled": False}
+            )
+            if isinstance(resp, dict) and resp.get("_error"):
+                self.app.console.print(f"[red]禁用失败: {resp.get('detail')}[/red]")
+            else:
+                self.app.console.print(f"[yellow]✓ {query} 已禁用[/yellow]")
+        else:
+            self.app.console.print("""[cyan]技能子命令:[/cyan]
+  /skill list                   列出所有技能
+  /skill search <关键词>        搜索技能
+  /skill enable <name>          启用技能
+  /skill disable <name>         禁用技能""")
+
+    async def _skills_list(self) -> None:
+        resp = await self.app._http_get("/api/skills")
+        if isinstance(resp, dict) and resp.get("_error"):
+            self.app.console.print(f"[red]获取失败: {resp.get('detail')}[/red]")
+            return
+        skills = resp if isinstance(resp, list) else []
+        if not skills:
+            self.app.console.print("[dim]暂无技能[/dim]")
+            return
+        self.app.console.print(f"\n[bold]已加载技能[/bold] ({len(skills)} 个)\n")
+        for s in skills:
+            status = "[green]✓[/green]" if s.get("enabled", True) else "[red]✗[/red]"
+            cat = s.get("category", "")
+            desc = (s.get("description") or "")[:40]
+            self.app.console.print(f"  {status} {s['name']:24s}  {cat:10s}  {desc}")
+        self.app.console.print()
+
+    # ── 帮助 ──────────────────────────────
 
     def _show_help(self) -> None:
         self.app.console.print("""
 [bold]AgentOS CLI[/bold]
 
   [cyan]会话[/cyan]
-    /new [agent]       创建新会话
-    /sessions          列出历史会话
-    /switch <id>       切换会话
-    /history           消息历史
-    /current           当前会话信息
-    /cancel            取消当前轮次
+    /new [agent]                     创建新会话
+    /session list                    列出历史会话
+    /session switch <id>             切换会话
+    /session current                 当前会话信息
+    /history                         消息历史
 
   [cyan]Agent[/cyan]
-    /agents            列出可用 Agent
+    /agent list                      列出可用 Agent
+    /agent create <id> <name>        创建 Agent
+    /agent delete <id>               删除 Agent
+    /agent info [id]                 查看 Agent 详情
+    /agent switch <id>               切换 Agent（创建新会话）
+    /agent config <id> <key> <val>   修改 Agent 配置
+
+  [cyan]工具[/cyan]
+    /tool list                 列出所有工具
+    /tool enable <name>        启用工具
+    /tool disable <name>       禁用工具
+
+  [cyan]技能[/cyan]
+    /skill list                列出所有技能
+    /skill search <词>         搜索技能
+    /skill enable <name>       启用技能
+    /skill disable <name>      禁用技能
 
   [cyan]系统[/cyan]
-    /debug on|off      调试模式
-    /help              显示帮助
-    /quit              退出
+    /debug on|off              调试模式
+    /help                      显示帮助
+    /quit                      退出
+
+  [dim]按 Tab 键可补全命令和子命令[/dim]
 """)
+
+
+def urllib_quote(s: str) -> str:
+    """URL 编码辅助"""
+    import urllib.parse
+    return urllib.parse.quote(s, safe="")

--- a/agentos/app/cli/display.py
+++ b/agentos/app/cli/display.py
@@ -1,10 +1,12 @@
-"""DisplayEngine + 确认交互 + 跨平台输入"""
+"""DisplayEngine + 确认交互 + 跨平台输入 + spinner"""
 
 from __future__ import annotations
 
 import asyncio
 import json
 import sys
+import threading
+import time
 import unicodedata
 from typing import TYPE_CHECKING
 
@@ -17,6 +19,7 @@ ANSI_RESET = "\033[0m"
 ANSI_GREEN = "\033[32m"
 ANSI_CYAN = "\033[36m"
 ANSI_YELLOW = "\033[33m"
+ANSI_DIM = "\033[2m"
 
 # 跨平台 termios 导入
 HAS_TERMIOS = False
@@ -27,6 +30,65 @@ if sys.platform != "win32":
         HAS_TERMIOS = True
     except ImportError:
         pass
+
+
+# ── 终端状态管理（线程安全） ──────────────────────────
+
+class TerminalGuard:
+    """管理终端 raw/cooked 模式切换，确保异步打印不会在 raw mode 下输出。"""
+
+    def __init__(self):
+        self._lock = threading.Lock()
+        self._fd: int | None = None
+        self._original: list | None = None
+        self._in_raw = False
+        self._buffer: list[str] = []  # 当前输入缓冲区引用
+
+    def enter_raw(self, fd: int, original_settings: list, buffer: list[str]) -> None:
+        with self._lock:
+            self._fd = fd
+            self._original = original_settings
+            self._in_raw = True
+            self._buffer = buffer
+
+    def exit_raw(self) -> None:
+        with self._lock:
+            self._in_raw = False
+            self._fd = None
+            self._original = None
+            self._buffer = []
+
+    def cooked(self) -> "_CookedContext":
+        """上下文管理器：临时恢复 cooked mode 用于安全打印"""
+        return _CookedContext(self)
+
+
+class _CookedContext:
+    def __init__(self, guard: TerminalGuard):
+        self._guard = guard
+        self._was_raw = False
+
+    def __enter__(self):
+        self._guard._lock.acquire()
+        if self._guard._in_raw and self._guard._fd is not None and HAS_TERMIOS:
+            self._was_raw = True
+            # 清除当前输入行
+            sys.stdout.write("\r\033[K")
+            sys.stdout.flush()
+            termios.tcsetattr(self._guard._fd, termios.TCSADRAIN, self._guard._original)
+        return self
+
+    def __exit__(self, *args):
+        if self._was_raw and self._guard._fd is not None and HAS_TERMIOS:
+            tty.setraw(self._guard._fd)
+            # 重绘提示符和输入内容
+            sys.stdout.write(f"{ANSI_GREEN}You{ANSI_RESET}: {''.join(self._guard._buffer)}")
+            sys.stdout.flush()
+        self._guard._lock.release()
+
+
+# 全局单例
+terminal_guard = TerminalGuard()
 
 
 def char_display_width(char: str) -> int:
@@ -40,10 +102,25 @@ def char_display_width(char: str) -> int:
     return 1
 
 
+def _show_completions(completions: list[str]) -> None:
+    """在终端中显示补全项列表（raw mode 下使用 \r\n）"""
+    sys.stdout.write(f"\r\n{ANSI_CYAN}可选:{ANSI_RESET} ")
+    sys.stdout.write(f"  ".join(f"{ANSI_YELLOW}{c}{ANSI_RESET}" for c in completions))
+    sys.stdout.write("\r\n")
+
+
+def _redraw_prompt(buffer: list[str]) -> None:
+    """重绘提示符和当前输入内容"""
+    sys.stdout.write(f"{ANSI_GREEN}You{ANSI_RESET}: {''.join(buffer)}")
+    sys.stdout.flush()
+
+
 def read_user_input() -> str:
-    """读取用户输入，支持在空输入时按 / 立即弹出命令菜单。
+    """读取用户输入，支持 Tab 补全和 / 即时菜单。
     Windows / 非 TTY 环境降级为 input()。
     """
+    from agentos.app.cli.commands import get_completions
+
     if not (HAS_TERMIOS and sys.stdin.isatty()):
         return input("You: ")
 
@@ -54,6 +131,7 @@ def read_user_input() -> str:
     buffer: list[str] = []
     try:
         tty.setraw(fd)
+        terminal_guard.enter_raw(fd, old_settings, buffer)
         while True:
             char = sys.stdin.read(1)
             if not char:
@@ -87,37 +165,107 @@ def read_user_input() -> str:
                     sys.stdout.flush()
                 continue
 
-            # 空缓冲区按 / 即时触发菜单提示
+            # Tab 补全
+            if char == "\t":
+                current = "".join(buffer)
+                if current.startswith("/"):
+                    completions = get_completions(current)
+                    if len(completions) == 1:
+                        # 唯一匹配：自动补全
+                        match = completions[0]
+                        if " " in current:
+                            # 补全子命令部分
+                            parts = current.split(maxsplit=1)
+                            prefix = parts[1] if len(parts) > 1 else ""
+                            suffix = match[len(prefix):]
+                            # 补全后加空格方便继续输入
+                            fill = suffix + " "
+                        else:
+                            # 补全顶层命令
+                            fill = match[len(current):] + " "
+                        for ch in fill:
+                            buffer.append(ch)
+                            sys.stdout.write(ch)
+                        sys.stdout.flush()
+                    elif completions:
+                        # 多个匹配：显示列表
+                        _show_completions(completions)
+                        _redraw_prompt(buffer)
+                continue
+
+            # 空缓冲区按 / 即时触发命令菜单
             current = "".join(buffer)
             if char == "/" and current == "":
                 buffer.append(char)
                 sys.stdout.write(char)
                 sys.stdout.write(f"\r\n{ANSI_CYAN}可用命令:{ANSI_RESET}\r\n")
-                sys.stdout.write(f"  {ANSI_YELLOW}/new [agent]{ANSI_RESET}    创建新会话\r\n")
-                sys.stdout.write(f"  {ANSI_YELLOW}/sessions{ANSI_RESET}       列出历史会话\r\n")
-                sys.stdout.write(f"  {ANSI_YELLOW}/switch <id>{ANSI_RESET}    切换会话\r\n")
-                sys.stdout.write(f"  {ANSI_YELLOW}/history{ANSI_RESET}        消息历史\r\n")
-                sys.stdout.write(f"  {ANSI_YELLOW}/agents{ANSI_RESET}         列出 Agent\r\n")
-                sys.stdout.write(f"  {ANSI_YELLOW}/debug on|off{ANSI_RESET}   调试模式\r\n")
-                sys.stdout.write(f"  {ANSI_YELLOW}/help{ANSI_RESET}           帮助\r\n")
-                sys.stdout.write(f"  {ANSI_YELLOW}/quit{ANSI_RESET}           退出\r\n")
-                sys.stdout.write(f"{ANSI_GREEN}You{ANSI_RESET}: {''.join(buffer)}")
-                sys.stdout.flush()
+                sys.stdout.write(f"  {ANSI_YELLOW}/new{ANSI_RESET}        {ANSI_YELLOW}/session{ANSI_RESET}     {ANSI_YELLOW}/agent{ANSI_RESET}      {ANSI_YELLOW}/tool{ANSI_RESET}       {ANSI_YELLOW}/skill{ANSI_RESET}\r\n")
+                sys.stdout.write(f"  {ANSI_YELLOW}/history{ANSI_RESET}    {ANSI_YELLOW}/debug{ANSI_RESET}       {ANSI_YELLOW}/help{ANSI_RESET}       {ANSI_YELLOW}/quit{ANSI_RESET}\r\n")
+                sys.stdout.write(f"  {ANSI_DIM}按 Tab 补全子命令{ANSI_RESET}\r\n")
+                _redraw_prompt(buffer)
                 continue
 
             buffer.append(char)
             sys.stdout.write(char)
             sys.stdout.flush()
     finally:
+        terminal_guard.exit_raw()
         termios.tcsetattr(fd, termios.TCSADRAIN, old_settings)
 
 
+# ── Spinner ──────────────────────────────────────────
+
+class Spinner:
+    """终端动态 spinner，显示 Agent 正在处理"""
+
+    FRAMES = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"]
+
+    def __init__(self, message: str = "思考中"):
+        self._message = message
+        self._stop_event = threading.Event()
+        self._thread: threading.Thread | None = None
+
+    def start(self) -> None:
+        self._stop_event.clear()
+        self._thread = threading.Thread(target=self._spin, daemon=True)
+        self._thread.start()
+
+    def stop(self) -> None:
+        self._stop_event.set()
+        if self._thread:
+            self._thread.join(timeout=1)
+            self._thread = None
+        # 清除 spinner 行
+        sys.stdout.write("\r\033[K")
+        sys.stdout.flush()
+
+    def update_message(self, message: str) -> None:
+        self._message = message
+
+    def _spin(self) -> None:
+        idx = 0
+        while not self._stop_event.is_set():
+            frame = self.FRAMES[idx % len(self.FRAMES)]
+            sys.stdout.write(f"\r{ANSI_CYAN}{frame} {self._message}...{ANSI_RESET}\033[K")
+            sys.stdout.flush()
+            idx += 1
+            self._stop_event.wait(0.1)
+
+
 class DisplayEngine:
-    """CLI 显示引擎：处理事件展示和确认交互"""
+    """CLI 显示引擎：处理事件展示和确认交互。
+    所有输出通过 _print 方法，确保在 raw mode 下安全打印。
+    """
 
     def __init__(self, app: CLIApp):
         self.app = app
         self.console: Console = app.console
+        self.spinner = Spinner()
+
+    def _print(self, *args, **kwargs) -> None:
+        """线程安全打印：临时退出 raw mode → 打印 → 恢复 raw mode"""
+        with terminal_guard.cooked():
+            self.console.print(*args, **kwargs)
 
     def handle_event(self, data: dict) -> None:
         """处理从 WebSocket 接收到的事件"""
@@ -125,32 +273,40 @@ class DisplayEngine:
         payload = data.get("payload", {})
 
         if msg_type == "tool_execution":
+            self.spinner.update_message("执行工具")
             name = payload.get("tool_name", "")
             args = payload.get("arguments", {})
-            self.console.print(f"[yellow]🔧 {name}[/yellow]")
             args_str = json.dumps(args, ensure_ascii=False)
             if len(args_str) > 300:
                 args_str = args_str[:300] + "..."
-            self.console.print(f"[dim]   参数: {args_str}[/dim]")
+            with terminal_guard.cooked():
+                sys.stdout.write("\r\033[K")
+                self.console.print(f"[yellow]🔧 {name}[/yellow]")
+                self.console.print(f"[dim]   参数: {args_str}[/dim]")
 
         elif msg_type == "tool_result":
             name = payload.get("tool_name", "")
             result = payload.get("result", {})
             success = payload.get("success", False)
-            if isinstance(result, dict) and result.get("action") == "need_grant":
-                self.console.print(f"[yellow]🔒 {name}: 目录未授权 {result.get('path', '')}[/yellow]")
-                return
-            icon = "✓" if success else "✗"
-            self.console.print(f"[yellow]{icon} {name}[/yellow]")
-            result_str = json.dumps(result, ensure_ascii=False)
-            if len(result_str) > 500:
-                result_str = result_str[:500] + "..."
-            self.console.print(f"[dim]   结果: {result_str}[/dim]")
+            with terminal_guard.cooked():
+                sys.stdout.write("\r\033[K")
+                if isinstance(result, dict) and result.get("action") == "need_grant":
+                    self.console.print(f"[yellow]🔒 {name}: 目录未授权 {result.get('path', '')}[/yellow]")
+                    return
+                icon = "✓" if success else "✗"
+                self.console.print(f"[yellow]{icon} {name}[/yellow]")
+                result_str = json.dumps(result, ensure_ascii=False)
+                if len(result_str) > 500:
+                    result_str = result_str[:500] + "..."
+                self.console.print(f"[dim]   结果: {result_str}[/dim]")
 
         elif msg_type == "agent_thinking":
+            desc = payload.get("description", payload.get("step_type", ""))
+            self.spinner.update_message(desc or "思考中")
             if self.app.debug:
-                desc = payload.get("description", payload.get("step_type", ""))
-                self.console.print(f"[dim]   ⏳ {desc}[/dim]")
+                with terminal_guard.cooked():
+                    sys.stdout.write("\r\033[K")
+                    self.console.print(f"[dim]   ⏳ {desc}[/dim]")
 
         elif msg_type == "sessions_list":
             self._render_sessions(payload.get("sessions", []))
@@ -161,86 +317,122 @@ class DisplayEngine:
         elif msg_type == "messages_list":
             self._render_messages(payload.get("messages", []))
 
+        elif msg_type == "session_deleted":
+            sid = payload.get("session_id", "")
+            self._print(f"[green]✓ 会话已删除: {sid}[/green]")
+
+        elif msg_type == "session_renamed":
+            sid = payload.get("session_id", "")
+            title = payload.get("title", "")
+            self._print(f"[green]✓ 会话已重命名: {sid} -> {title}[/green]")
+
+        elif msg_type == "session_created":
+            sid = data.get("session_id", "")
+            if sid:
+                self.app.current_session_id = sid
+
+        elif msg_type == "session_loaded":
+            pass  # session_id 已在 _load_session 中设置
+
         elif msg_type == "notification":
             text = payload.get("text", "")
-            self.console.print(f"\n[cyan]📢 通知:[/cyan] {text}")
+            self._print(f"\n[cyan]📢 通知:[/cyan] {text}")
 
     def show_response(self, text: str) -> None:
+        self.spinner.stop()
         if text:
-            self.console.print(f"\n[blue]Assistant:[/blue] {text}\n")
+            self._print(f"\n[blue]Assistant:[/blue] {text}\n")
 
     def show_error(self, data: dict) -> None:
+        self.spinner.stop()
         msg = data.get("payload", {}).get("message", "未知错误")
-        self.console.print(f"\n[red]错误: {msg}[/red]\n")
+        self._print(f"\n[red]错误: {msg}[/red]\n")
 
     def show_debug(self, data: dict) -> None:
         msg_type = data.get("type", "?")
         payload_str = str(data.get("payload", {}))[:80]
-        self.console.print(f"[dim]  [DEBUG] {msg_type}  {payload_str}[/dim]")
+        with terminal_guard.cooked():
+            sys.stdout.write("\r\033[K")
+            self.console.print(f"[dim]  [DEBUG] {msg_type}  {payload_str}[/dim]")
 
-    def show_welcome(self) -> None:
+    def show_welcome(self, agent_name: str = "", workdir: str = "") -> None:
+        """显示欢迎信息，包含 Agent 名称和工作目录"""
+        self.console.print()
         self.console.print(f"[green]✓ 已连接[/green]  会话: {self.app.current_session_id or '?'}")
-        self.console.print("[dim]输入消息开始对话，输入 / 查看命令[/dim]\n")
+        agent_display = agent_name or self.app.current_agent_id
+        self.console.print(f"  Agent:  [bold cyan]{agent_display}[/bold cyan]")
+        if workdir:
+            self.console.print(f"  工作目录: [dim]{workdir}[/dim]")
+        self.console.print("[dim]输入消息开始对话，输入 / 查看命令，Ctrl+C 中止当前对话[/dim]\n")
+
+    def show_cancelled(self) -> None:
+        """显示对话已中止"""
+        self.spinner.stop()
+        self._print("\n[yellow]⚠ 对话已中止[/yellow]\n")
 
     async def prompt_confirmation(self, data: dict) -> bool:
         """工具确认交互"""
+        self.spinner.stop()
         payload = data.get("payload", {})
         tool_name = payload.get("tool_name", "")
         risk = payload.get("risk_level", "high")
         arguments = payload.get("arguments", {})
 
-        self.console.print()
-        self.console.print(f"  ⚠️  [bold yellow]{tool_name}[/] 请求执行 ({risk} 风险):")
+        self._print()
+        self._print(f"  ⚠️  [bold yellow]{tool_name}[/] 请求执行 ({risk} 风险):")
         for k, v in arguments.items():
             if k.startswith("_"):
                 continue
-            self.console.print(f"     {k}: {str(v)[:200]}", style="dim")
+            self._print(f"     {k}: {str(v)[:200]}", style="dim")
 
         resp = await asyncio.to_thread(input, "  批准？[y/N]: ")
         approved = resp.strip().lower() in ("y", "yes")
         icon = "✅" if approved else "❌"
-        self.console.print(f"  {icon} {'已批准' if approved else '已拒绝'}\n")
+        self._print(f"  {icon} {'已批准' if approved else '已拒绝'}\n")
         return approved
 
     def _render_sessions(self, sessions: list[dict]) -> None:
-        if not sessions:
-            self.console.print("[dim]暂无会话[/dim]")
-            return
-        self.console.print(f"\n[bold]会话列表[/bold] ({len(sessions)} 个)\n")
-        for s in sessions:
-            sid = s.get("session_id", "?")
-            title = s.get("title", "(无标题)")[:30]
-            agent = s.get("agent_id", "default")
-            marker = " *" if sid == self.app.current_session_id else ""
-            self.console.print(f"  {sid}{marker}  {agent:16s}  {title}")
-        self.console.print()
+        with terminal_guard.cooked():
+            if not sessions:
+                self.console.print("[dim]暂无会话[/dim]")
+                return
+            self.console.print(f"\n[bold]会话列表[/bold] ({len(sessions)} 个)\n")
+            for s in sessions:
+                sid = s.get("session_id", "?")
+                title = s.get("title", "(无标题)")[:30]
+                agent = s.get("agent_id", "default")
+                marker = " *" if sid == self.app.current_session_id else ""
+                self.console.print(f"  {sid}{marker}  {agent:16s}  {title}")
+            self.console.print()
 
     def _render_agents(self, agents: list[dict]) -> None:
-        if not agents:
-            self.console.print("[dim]暂无 Agent[/dim]")
-            return
-        self.console.print(f"\n[bold]可用 Agent[/bold] ({len(agents)} 个)\n")
-        for a in agents:
-            aid = a.get("id", "?")
-            model = a.get("model", "")
-            desc = a.get("description", "")[:40]
-            self.console.print(f"  {aid:20s}  {model:16s}  {desc}")
-        self.console.print()
+        with terminal_guard.cooked():
+            if not agents:
+                self.console.print("[dim]暂无 Agent[/dim]")
+                return
+            self.console.print(f"\n[bold]可用 Agent[/bold] ({len(agents)} 个)\n")
+            for a in agents:
+                aid = a.get("id", "?")
+                model = a.get("model", "")
+                desc = a.get("description", "")[:40]
+                self.console.print(f"  {aid:20s}  {model:16s}  {desc}")
+            self.console.print()
 
     def _render_messages(self, messages: list[dict]) -> None:
         """渲染会话消息历史"""
-        if not messages:
-            self.console.print("[dim]暂无消息[/dim]")
-            return
-        self.console.print(f"\n[bold]消息历史[/bold] ({len(messages)} 条)\n")
-        for m in messages:
-            role = m.get("role", "?")
-            content = m.get("content", "")
-            if role == "user":
-                self.console.print(f"  [green]You:[/green] {content[:200]}")
-            elif role == "assistant":
-                self.console.print(f"  [blue]Assistant:[/blue] {content[:200]}")
-            elif role == "tool":
-                name = m.get("name", m.get("tool_name", ""))
-                self.console.print(f"  [yellow]🔧 {name}[/yellow]: {content[:100]}")
-        self.console.print()
+        with terminal_guard.cooked():
+            if not messages:
+                self.console.print("[dim]暂无消息[/dim]")
+                return
+            self.console.print(f"\n[bold]消息历史[/bold] ({len(messages)} 条)\n")
+            for m in messages:
+                role = m.get("role", "?")
+                content = m.get("content", "")
+                if role == "user":
+                    self.console.print(f"  [green]You:[/green] {content[:200]}")
+                elif role == "assistant":
+                    self.console.print(f"  [blue]Assistant:[/blue] {content[:200]}")
+                elif role == "tool":
+                    name = m.get("name", m.get("tool_name", ""))
+                    self.console.print(f"  [yellow]🔧 {name}[/yellow]: {content[:100]}")
+            self.console.print()

--- a/agentos/app/gateway/main.py
+++ b/agentos/app/gateway/main.py
@@ -546,6 +546,54 @@ async def websocket_endpoint(websocket: WebSocket):
                 continue
 
 
+            # v1.5: 删除会话
+            if msg_type == "delete_session":
+                sid = payload.get("session_id")
+                if sid:
+                    try:
+                        await repo.delete_session_cascade(sid)
+                        ws_channel._session_bindings.pop(sid, None)
+                        await ws_channel.send_json(websocket, {
+                            "type": "session_deleted",
+                            "payload": {"session_id": sid},
+                            "timestamp": time.time(),
+                        })
+                        logger.info(f"Session deleted: {sid}")
+                    except Exception as e:
+                        await ws_channel.send_json(websocket, {
+                            "type": "error",
+                            "payload": {"message": f"删除会话失败: {e}"},
+                            "timestamp": time.time(),
+                        })
+                continue
+
+            # v1.5: 重命名会话
+            if msg_type == "rename_session":
+                sid = payload.get("session_id") or session_id
+                title = payload.get("title", "")
+                if sid and title:
+                    try:
+                        await repo.update_session_title(sid, title)
+                        await ws_channel.send_json(websocket, {
+                            "type": "session_renamed",
+                            "payload": {"session_id": sid, "title": title},
+                            "timestamp": time.time(),
+                        })
+                        logger.info(f"Session renamed: {sid} -> {title}")
+                    except Exception as e:
+                        await ws_channel.send_json(websocket, {
+                            "type": "error",
+                            "payload": {"message": f"重命名会话失败: {e}"},
+                            "timestamp": time.time(),
+                        })
+                else:
+                    await ws_channel.send_json(websocket, {
+                        "type": "error",
+                        "payload": {"message": "需要 session_id 和 title"},
+                        "timestamp": time.time(),
+                    })
+                continue
+
             # v1.4: 列出可用 Agent
             if msg_type == "list_agents":
                 agent_registry = app.state.agent_registry

--- a/agentos/app/main.py
+++ b/agentos/app/main.py
@@ -1,0 +1,216 @@
+#!/usr/bin/env python3
+"""AgentOS 统一 CLI 入口
+
+用法:
+    agentos run [--port 8000] [--frontend-port 3000] [--no-frontend]
+    agentos cli [--host localhost] [--port 8000] [--agent default] [--session ID] [--debug] [-e MSG]
+    agentos version
+"""
+from __future__ import annotations
+
+import argparse
+import asyncio
+import os
+import signal
+import subprocess
+import sys
+import time
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[2]
+WEB_DIR = Path(__file__).resolve().parent / "web"
+
+
+def _find_npm() -> str:
+    """查找 npm 可执行文件路径"""
+    import shutil
+    npm = shutil.which("npm")
+    if not npm:
+        return ""
+    return npm
+
+
+# ── agentos run ──────────────────────────────────────
+
+def _check_port(port: int) -> bool:
+    """检查端口是否可用（尝试连接，连上说明被占用）"""
+    import socket
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as s:
+        s.settimeout(0.5)
+        try:
+            s.connect(("127.0.0.1", port))
+            return False  # 连上了，说明已被占用
+        except (ConnectionRefusedError, OSError):
+            return True  # 连不上，说明空闲
+
+
+def cmd_run(args: argparse.Namespace) -> int:
+    """启动后端服务 + 前端 dashboard"""
+    backend_port = args.port
+    frontend_port = args.frontend_port
+    no_frontend = args.no_frontend
+
+    # 端口检查
+    if not _check_port(backend_port):
+        print(f"错误: 端口 {backend_port} 已被占用", file=sys.stderr)
+        return 1
+    if not no_frontend and not _check_port(frontend_port):
+        print(f"错误: 端口 {frontend_port} 已被占用", file=sys.stderr)
+        return 1
+
+    procs: list[subprocess.Popen] = []
+
+    def cleanup(signum=None, frame=None):
+        for p in procs:
+            try:
+                p.terminate()
+            except OSError:
+                pass
+        # 等待子进程退出
+        for p in procs:
+            try:
+                p.wait(timeout=5)
+            except subprocess.TimeoutExpired:
+                p.kill()
+
+    signal.signal(signal.SIGINT, cleanup)
+    signal.signal(signal.SIGTERM, cleanup)
+
+    # 启动后端
+    backend_cmd = [
+        sys.executable, "-m", "uvicorn",
+        "agentos.app.gateway.main:app",
+        "--reload",
+        "--host", "0.0.0.0",
+        "--port", str(backend_port),
+    ]
+    print(f"启动后端服务: http://localhost:{backend_port}")
+    backend_proc = subprocess.Popen(backend_cmd, cwd=str(PROJECT_ROOT))
+    procs.append(backend_proc)
+
+    # 等待后端启动
+    time.sleep(2)
+    if backend_proc.poll() is not None:
+        print("错误: 后端启动失败", file=sys.stderr)
+        return 1
+
+    # 启动前端
+    frontend_proc = None
+    if not no_frontend:
+        npm = _find_npm()
+        if not npm:
+            print("警告: 未找到 npm，跳过前端启动。安装 Node.js 后可使用前端 dashboard。", file=sys.stderr)
+        elif not (WEB_DIR / "node_modules").exists():
+            print("警告: 前端依赖未安装，请先执行 'npm install'。跳过前端启动。", file=sys.stderr)
+        else:
+            print(f"启动前端 dashboard: http://localhost:{frontend_port}")
+            env = os.environ.copy()
+            env["PORT"] = str(frontend_port)
+            frontend_proc = subprocess.Popen(
+                [npm, "run", "dev"],
+                cwd=str(WEB_DIR),
+                env=env,
+            )
+            procs.append(frontend_proc)
+
+            time.sleep(2)
+            if frontend_proc.poll() is not None:
+                print("错误: 前端启动失败", file=sys.stderr)
+                cleanup()
+                return 1
+
+    print()
+    print("=" * 50)
+    print(f"  AgentOS 已启动")
+    print(f"  后端 API:    http://localhost:{backend_port}")
+    if frontend_proc:
+        print(f"  Dashboard:   http://localhost:{frontend_port}")
+    print(f"  CLI 连接:    agentos cli --port {backend_port}")
+    print("=" * 50)
+    print("按 Ctrl+C 停止所有服务\n")
+
+    # 监控子进程
+    try:
+        while True:
+            if backend_proc.poll() is not None:
+                print("后端进程退出，正在停止所有服务。")
+                cleanup()
+                return 1
+            if frontend_proc and frontend_proc.poll() is not None:
+                print("前端进程退出，正在停止所有服务。")
+                cleanup()
+                return 1
+            time.sleep(1)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        cleanup()
+    return 0
+
+
+# ── agentos cli ──────────────────────────────────────
+
+def cmd_cli(args: argparse.Namespace) -> int:
+    """启动 CLI 客户端"""
+    from agentos.app.cli.app import CLIApp
+
+    app = CLIApp(
+        host=args.host,
+        port=args.port,
+        agent_id=args.agent,
+        session_id=args.session,
+        debug=args.debug,
+        execute=args.execute,
+    )
+    return asyncio.run(app.run())
+
+
+# ── agentos version ─────────────────────────────────
+
+def cmd_version(args: argparse.Namespace) -> int:
+    print("AgentOS v0.5.0")
+    return 0
+
+
+# ── 主入口 ───────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        prog="agentos",
+        description="AgentOS - 基于事件驱动架构的 AI Agent 平台",
+    )
+    subparsers = parser.add_subparsers(dest="command", help="可用命令")
+
+    # agentos run
+    run_parser = subparsers.add_parser("run", help="启动后端服务和前端 dashboard")
+    run_parser.add_argument("--port", type=int, default=8000, help="后端端口 (默认 8000)")
+    run_parser.add_argument("--frontend-port", type=int, default=3000, help="前端端口 (默认 3000)")
+    run_parser.add_argument("--no-frontend", action="store_true", help="仅启动后端，不启动前端")
+
+    # agentos cli
+    cli_parser = subparsers.add_parser("cli", help="启动 CLI 交互客户端")
+    cli_parser.add_argument("--host", default="localhost", help="后端地址 (默认 localhost)")
+    cli_parser.add_argument("--port", type=int, default=8000, help="后端端口 (默认 8000)")
+    cli_parser.add_argument("--agent", default=None, help="Agent ID")
+    cli_parser.add_argument("--session", default=None, help="恢复指定 session")
+    cli_parser.add_argument("--debug", action="store_true", help="调试模式")
+    cli_parser.add_argument("-e", "--execute", default=None, help="执行单条消息后退出")
+
+    # agentos version
+    subparsers.add_parser("version", help="显示版本号")
+
+    args = parser.parse_args()
+
+    if args.command == "run":
+        return cmd_run(args)
+    elif args.command == "cli":
+        return cmd_cli(args)
+    elif args.command == "version":
+        return cmd_version(args)
+    else:
+        parser.print_help()
+        return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/package.json
+++ b/package.json
@@ -4,8 +4,8 @@
   "version": "0.5.0",
   "scripts": {
     "postinstall": "bash ./scripts/postinstall.sh",
-    "dev": "bash ./scripts/dev.sh",
-    "dev:server": "python3 -m uvicorn agentos.app.gateway.main:app --reload --host 0.0.0.0 --port 8000",
+    "dev": "python3 -m agentos.app.main run",
+    "dev:server": "python3 -m agentos.app.main run --no-frontend",
     "dev:web": "cd agentos/app/web && npm run dev",
     "test": "python3 -m pytest tests/ -q",
     "test:unit": "python3 -m pytest tests/unit/ -q",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,9 @@ dev = [
   "pytest-asyncio>=0.24.0",
 ]
 
+[project.scripts]
+agentos = "agentos.app.main:main"
+
 [tool.pytest.ini_options]
 asyncio_mode = "auto"
 pythonpath = ["."]

--- a/tests/helpers/__init__.py
+++ b/tests/helpers/__init__.py
@@ -25,8 +25,14 @@ class MockCLIApp:
         self.current_agent_id = "default"
         self.console = type("C", (), {"print": lambda *a, **k: None, "output": []})()
         self._sent = []
+        self._http_responses: dict[str, Any] = {}
+        self._turn_cancelled = False
+        self._recv_loop_running = True
 
     async def _send(self, msg):
+        self._sent.append(msg)
+
+    async def _send_query(self, msg, timeout=5.0):
         self._sent.append(msg)
 
     async def _create_session(self, aid=None):
@@ -39,3 +45,20 @@ class MockCLIApp:
 
     async def _wait_for_turn(self):
         pass
+
+    # HTTP 客户端 mock
+    async def _http(self, method: str, path: str, body: dict | None = None) -> dict:
+        key = f"{method} {path}"
+        return self._http_responses.get(key, {"_mock": True})
+
+    async def _http_get(self, path: str) -> dict:
+        return await self._http("GET", path)
+
+    async def _http_post(self, path: str, body: dict | None = None) -> dict:
+        return await self._http("POST", path, body)
+
+    async def _http_put(self, path: str, body: dict | None = None) -> dict:
+        return await self._http("PUT", path, body)
+
+    async def _http_delete(self, path: str) -> dict:
+        return await self._http("DELETE", path)

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -1,4 +1,4 @@
-"""C01: CommandDispatcher 命令分派
+"""C01: CommandDispatcher 命令分派 + Tab 补全
 
 使用真实 MockCLIApp（tests/helpers 中的纯 Python 实现），无 mock。
 """
@@ -8,7 +8,7 @@ import os
 # 注入 tests/ 目录到 sys.path，以便 import helpers（测试辅助模块）
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
 from helpers import MockCLIApp
-from agentos.app.cli.commands import CommandDispatcher
+from agentos.app.cli.commands import CommandDispatcher, get_completions
 
 
 class TestCommandDispatcher:
@@ -37,11 +37,11 @@ class TestCommandDispatcher:
         d = CommandDispatcher(app)
         assert await d.dispatch("/debug") is None
 
-    async def test_current(self):
+    async def test_session_current(self):
         app = MockCLIApp()
         app.current_session_id = "s1"
         d = CommandDispatcher(app)
-        assert await d.dispatch("/current") is None
+        assert await d.dispatch("/session current") is None
 
     async def test_unknown(self):
         d = CommandDispatcher(MockCLIApp())
@@ -59,26 +59,188 @@ class TestCommandDispatcher:
         await d.dispatch("/new helper")
         assert app.current_agent_id == "helper"
 
-    async def test_sessions_list(self):
+    # ── /session 命令 ──────────────────────────
+
+    async def test_session_list(self):
         app = MockCLIApp()
         d = CommandDispatcher(app)
-        await d.dispatch("/sessions")
+        await d.dispatch("/session list")
         assert any(m.get("type") == "list_sessions" for m in app._sent)
 
-    async def test_agents_list(self):
+    async def test_session_bare(self):
+        """裸 /session 等同于 /session list"""
         app = MockCLIApp()
         d = CommandDispatcher(app)
-        await d.dispatch("/agents")
-        assert any(m.get("type") == "list_agents" for m in app._sent)
+        await d.dispatch("/session")
+        assert any(m.get("type") == "list_sessions" for m in app._sent)
 
-    async def test_switch_no_arg(self):
+    async def test_session_switch_no_arg(self):
         app = MockCLIApp()
         d = CommandDispatcher(app)
-        await d.dispatch("/switch")
+        await d.dispatch("/session switch")
         # 不应崩溃
 
-    async def test_switch_with_arg(self):
+    async def test_session_switch_with_arg(self):
         app = MockCLIApp()
         d = CommandDispatcher(app)
-        await d.dispatch("/switch s123")
+        await d.dispatch("/session switch s123")
         assert app.current_session_id == "s123"
+
+    # ── /agent 命令 ──────────────────────────
+
+    async def test_agent_list(self):
+        """裸 /agent 等同于 /agent list"""
+        app = MockCLIApp()
+        d = CommandDispatcher(app)
+        await d.dispatch("/agent")
+        assert any(m.get("type") == "list_agents" for m in app._sent)
+
+    async def test_agent_list_explicit(self):
+        app = MockCLIApp()
+        d = CommandDispatcher(app)
+        await d.dispatch("/agent list")
+        assert any(m.get("type") == "list_agents" for m in app._sent)
+
+    async def test_agent_create(self):
+        app = MockCLIApp()
+        app._http_responses["POST /api/agents"] = {"id": "helper", "model": "gpt-4o"}
+        d = CommandDispatcher(app)
+        await d.dispatch("/agent create helper 助手Agent")
+
+    async def test_agent_delete(self):
+        app = MockCLIApp()
+        app._http_responses["DELETE /api/agents/helper"] = {"status": "deleted"}
+        d = CommandDispatcher(app)
+        await d.dispatch("/agent delete helper")
+
+    async def test_agent_info(self):
+        app = MockCLIApp()
+        app._http_responses["GET /api/agents/default"] = {
+            "id": "default", "name": "Default", "description": "",
+            "provider": "openai", "model": "gpt-4o-mini",
+            "temperature": 0.2, "maxTokens": None,
+            "toolCount": 5, "skillCount": 3, "sessionCount": 2,
+            "tools": [], "skills": [],
+        }
+        d = CommandDispatcher(app)
+        await d.dispatch("/agent info default")
+
+    async def test_agent_switch(self):
+        app = MockCLIApp()
+        app._http_responses["GET /api/agents/helper"] = {"id": "helper"}
+        d = CommandDispatcher(app)
+        await d.dispatch("/agent switch helper")
+        assert app.current_agent_id == "helper"
+        assert app.current_session_id == "mock_sess"
+
+    # ── /tool 命令 ──────────────────────────
+
+    async def test_tool_list(self):
+        app = MockCLIApp()
+        app._http_responses["GET /api/tools"] = [
+            {"name": "bash_command", "enabled": True, "riskLevel": "high", "description": "执行命令"},
+        ]
+        d = CommandDispatcher(app)
+        await d.dispatch("/tool list")
+
+    async def test_tool_bare(self):
+        """裸 /tool 等同于 /tool list"""
+        app = MockCLIApp()
+        app._http_responses["GET /api/tools"] = []
+        d = CommandDispatcher(app)
+        await d.dispatch("/tool")
+
+    async def test_tool_enable(self):
+        app = MockCLIApp()
+        app._http_responses["PUT /api/tools/bash_command/enabled"] = {"name": "bash_command", "enabled": True}
+        d = CommandDispatcher(app)
+        await d.dispatch("/tool enable bash_command")
+
+    async def test_tool_disable(self):
+        app = MockCLIApp()
+        app._http_responses["PUT /api/tools/bash_command/enabled"] = {"name": "bash_command", "enabled": False}
+        d = CommandDispatcher(app)
+        await d.dispatch("/tool disable bash_command")
+
+    # ── /skill 命令 ──────────────────────────
+
+    async def test_skill_list(self):
+        app = MockCLIApp()
+        app._http_responses["GET /api/skills"] = [
+            {"name": "pdf_to_markdown", "enabled": True, "category": "builtin", "description": "PDF转MD"},
+        ]
+        d = CommandDispatcher(app)
+        await d.dispatch("/skill list")
+
+    async def test_skill_bare(self):
+        """裸 /skill 等同于 /skill list"""
+        app = MockCLIApp()
+        app._http_responses["GET /api/skills"] = []
+        d = CommandDispatcher(app)
+        await d.dispatch("/skill")
+
+    async def test_skill_search(self):
+        app = MockCLIApp()
+        app._http_responses["GET /api/skills/search?q=pdf"] = {
+            "local_results": [{"name": "pdf_to_markdown", "description": "PDF转MD"}],
+            "remote_results": [],
+        }
+        d = CommandDispatcher(app)
+        await d.dispatch("/skill search pdf")
+
+
+class TestTabCompletion:
+    """测试 get_completions 补全逻辑"""
+
+    def test_empty_returns_all(self):
+        result = get_completions("")
+        assert "/session" in result
+        assert "/agent" in result
+        assert "/quit" in result
+
+    def test_slash_returns_all(self):
+        result = get_completions("/")
+        assert "/session" in result
+
+    def test_partial_top_command(self):
+        result = get_completions("/se")
+        assert "/session" in result
+        assert "/quit" not in result
+
+    def test_exact_top_command(self):
+        result = get_completions("/session")
+        assert result == ["/session"]
+
+    def test_session_subcommands(self):
+        result = get_completions("/session ")
+        assert "list" in result
+        assert "switch" in result
+
+    def test_session_partial_sub(self):
+        result = get_completions("/session sw")
+        assert result == ["switch"]
+
+    def test_agent_subcommands(self):
+        result = get_completions("/agent ")
+        assert "list" in result
+        assert "create" in result
+        assert "switch" in result
+
+    def test_tool_subcommands(self):
+        result = get_completions("/tool ")
+        assert "list" in result
+        assert "enable" in result
+
+    def test_skill_subcommands(self):
+        result = get_completions("/skill ")
+        assert "list" in result
+        assert "search" in result
+
+    def test_debug_subcommands(self):
+        result = get_completions("/debug ")
+        assert "on" in result
+        assert "off" in result
+
+    def test_no_match(self):
+        result = get_completions("/zzz")
+        assert result == []


### PR DESCRIPTION
## Summary

- **统一 CLI 入口**: `agentos run` 启动后端+前端, `agentos cli` 启动交互客户端, `agentos version` 查看版本
- **命令体系重构**: `/session list|switch|current`, `/agent list|create|delete|info|switch|config`, `/tool list|enable|disable`, `/skill list|search|enable|disable`
- **Tab 补全**: 支持顶层命令和子命令补全
- **交互体验优化**: 动态 spinner、Ctrl+C 中止对话、TerminalGuard 防止 raw mode 下输出错乱、查询命令等待响应后再回到输入提示
- **后端扩展**: 新增 delete_session / rename_session WebSocket 消息处理
- **HTTP 客户端**: CLI 通过 urllib 调用后端 REST API 实现 agent/tool/skill 管理

## Test plan

- [x] 37 个单元测试全部通过（命令分派 + Tab 补全）
- [ ] 手动验证 `agentos run` / `agentos cli` 启动流程
- [ ] 手动验证多客户端连接同一 session 输出不错乱
- [ ] 手动验证 Ctrl+C 中止对话后立即显示 `You:` 提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)