### PR TITLE
fix: 合并后 bug 修复（CORS/auth/WebSocket/会话恢复）

### DIFF
--- a/agentos/app/gateway/main.py
+++ b/agentos/app/gateway/main.py
@@ -339,9 +339,20 @@ async def token_auth_middleware(request: Request, call_next):
     if request.url.path in AUTH_WHITELIST:
         return await call_next(request)
 
+    # CORS 预检请求放行（OPTIONS 由 CORSMiddleware 处理）
+    if request.method == "OPTIONS":
+        return await call_next(request)
+
     # 验证 token
     if not hasattr(app.state, "services") or not verify_request(request, app.state.services.auth_service):
-        return JSONResponse(status_code=401, content={"detail": "Invalid or missing token"})
+        # 401 响应需要带 CORS 头，否则浏览器会拦截
+        origin = request.headers.get("origin", "")
+        headers = {}
+        allowed_origins = config.get("server.cors_origins", [])
+        if origin in allowed_origins:
+            headers["access-control-allow-origin"] = origin
+            headers["access-control-allow-credentials"] = "true"
+        return JSONResponse(status_code=401, content={"detail": "Invalid or missing token"}, headers=headers)
 
     return await call_next(request)
 

--- a/agentos/app/web/app/agents/[id]/page.tsx
+++ b/agentos/app/web/app/agents/[id]/page.tsx
@@ -5,8 +5,7 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft, Settings, Loader2, Save, Plus, FileText, Trash2, ChevronDown, ChevronRight, Wrench, Bot } from 'lucide-react';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { authFetch, API_BASE } from '@/lib/authFetch';
 
 interface ToolDetail { name: string; description: string; enabled: boolean; }
 interface SkillDetail { name: string; description: string; enabled: boolean; }
@@ -76,7 +75,7 @@ export default function AgentDetailPage() {
   });
 
   const loadAgent = useCallback(() => {
-    fetch(`${API_BASE}/api/agents/${agentId}`)
+    authFetch(`${API_BASE}/api/agents/${agentId}`)
       .then(res => res.json())
       .then(data => {
         setAgent(data);
@@ -107,7 +106,7 @@ export default function AgentDetailPage() {
   // 加载所有 agent 列表（用于委托配置）
   useEffect(() => {
     if (activeTab === 'config') {
-      fetch(`${API_BASE}/api/agents`)
+      authFetch(`${API_BASE}/api/agents`)
         .then(res => res.json())
         .then(data => setAllAgents(data.map((a: AgentSummary) => ({ id: a.id, name: a.name }))))
         .catch(() => setAllAgents([]));
@@ -130,7 +129,7 @@ export default function AgentDetailPage() {
         max_delegation_depth: parseInt(editMaxDepth) || 3,
       };
       if (editMaxTokens) body.max_tokens = parseInt(editMaxTokens) || undefined;
-      const res = await fetch(`${API_BASE}/api/agents/${agentId}/config`, {
+      const res = await authFetch(`${API_BASE}/api/agents/${agentId}/config`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(body),
@@ -152,7 +151,7 @@ export default function AgentDetailPage() {
 
   // Workspace 文件操作
   const loadWsFiles = useCallback(() => {
-    fetch(`${API_BASE}/api/workspace/files`)
+    authFetch(`${API_BASE}/api/workspace/files`)
       .then(res => res.json())
       .then(data => setWsFiles(data))
       .catch(() => setWsFiles([]));
@@ -163,7 +162,7 @@ export default function AgentDetailPage() {
   const loadFile = async (name: string) => {
     setSelectedFile(name); setFileLoading(true); setFileSaveMsg('');
     try {
-      const res = await fetch(`${API_BASE}/api/workspace/files/${name}`);
+      const res = await authFetch(`${API_BASE}/api/workspace/files/${name}`);
       const data = await res.json();
       setFileContent(data.content || '');
     } catch { setFileContent(''); }
@@ -174,7 +173,7 @@ export default function AgentDetailPage() {
     if (!selectedFile) return;
     setFileSaving(true); setFileSaveMsg('');
     try {
-      await fetch(`${API_BASE}/api/workspace/files/${selectedFile}`, {
+      await authFetch(`${API_BASE}/api/workspace/files/${selectedFile}`, {
         method: 'PUT', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ content: fileContent }),
       });
@@ -186,7 +185,7 @@ export default function AgentDetailPage() {
   const deleteFile = async (name: string) => {
     if (!confirm(`确定要删除 ${name} 吗?`)) return;
     try {
-      const res = await fetch(`${API_BASE}/api/workspace/files/${name}`, { method: 'DELETE' });
+      const res = await authFetch(`${API_BASE}/api/workspace/files/${name}`, { method: 'DELETE' });
       if (res.ok) { if (selectedFile === name) { setSelectedFile(null); setFileContent(''); } loadWsFiles(); }
     } catch { /* ignore */ }
   };
@@ -196,7 +195,7 @@ export default function AgentDetailPage() {
     if (!fname) return;
     if (!fname.endsWith('.md')) fname += '.md';
     try {
-      await fetch(`${API_BASE}/api/workspace/files/${fname}`, {
+      await authFetch(`${API_BASE}/api/workspace/files/${fname}`, {
         method: 'PUT', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ content: `# ${fname.replace('.md', '')}\n\n` }),
       });
@@ -208,7 +207,7 @@ export default function AgentDetailPage() {
   const savePreferences = async () => {
     setSaving(true); setSaveMsg('');
     try {
-      await fetch(`${API_BASE}/api/agents/${agentId}/preferences`, {
+      await authFetch(`${API_BASE}/api/agents/${agentId}/preferences`, {
         method: 'PUT', headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ tools: toolStates, skills: skillStates }),
       });

--- a/agentos/app/web/app/agents/page.tsx
+++ b/agentos/app/web/app/agents/page.tsx
@@ -9,8 +9,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { authFetch, API_BASE } from '@/lib/authFetch';
 
 interface Agent {
   id: string;
@@ -33,7 +32,7 @@ export default function OrchestrationPage() {
 
   const loadAgents = () => {
     setAgentsLoading(true);
-    fetch(`${API_BASE}/api/agents`)
+    authFetch(`${API_BASE}/api/agents`)
       .then(res => res.json())
       .then(data => setAgents(data))
       .catch(() => setAgents([]))
@@ -52,7 +51,7 @@ export default function OrchestrationPage() {
     e.stopPropagation();
     if (!confirm(`确定要删除 Agent "${agentId}" 吗？`)) return;
     try {
-      const res = await fetch(`${API_BASE}/api/agents/${agentId}`, { method: 'DELETE' });
+      const res = await authFetch(`${API_BASE}/api/agents/${agentId}`, { method: 'DELETE' });
       if (res.ok) loadAgents();
     } catch { /* ignore */ }
   };
@@ -221,7 +220,7 @@ function CreateAgentModal({ onClose, onCreated }: { onClose: () => void; onCreat
     setCreating(true);
     setError('');
     try {
-      const res = await fetch(`${API_BASE}/api/agents`, {
+      const res = await authFetch(`${API_BASE}/api/agents`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({

--- a/agentos/app/web/app/chat/page.tsx
+++ b/agentos/app/web/app/chat/page.tsx
@@ -442,7 +442,8 @@ function ChatPageInner() {
             }
           }
         } else if (et === 'agent.step_completed') {
-          const resp = p.final_response || '';
+          // 兼容两种格式：raw payload {result: {content}} 和映射后的 {final_response}
+          const resp = p.final_response || (p.result && p.result.content) || '';
           if (resp) rebuilt.push({ id: makeId(), role: 'assistant', content: resp, timestamp: Date.now() });
         }
       }

--- a/agentos/app/web/app/chat/page.tsx
+++ b/agentos/app/web/app/chat/page.tsx
@@ -286,30 +286,6 @@ function ChatPageInner() {
 
   // ── WebSocket ──
 
-  // 用 ref 保持 handleWsMessage 始终指向最新版本，避免 stale closure
-  const handleWsMessageRef = useRef<((data: Record<string, unknown>) => void) | null>(null);
-
-  useEffect(() => {
-    // 从 cookie 读取 token（Jupyter-lab 风格认证）
-    const cookieMatch = document.cookie.match(/(?:^|; )agentos_token=([^;]*)/);
-    const token = cookieMatch ? decodeURIComponent(cookieMatch[1]) : null;
-    const wsUrl = token ? `${WS_URL}?token=${encodeURIComponent(token)}` : WS_URL;
-    const ws = new WebSocket(wsUrl);
-    wsRef.current = ws;
-    ws.onopen = () => setWsConnected(true);
-    ws.onclose = () => setWsConnected(false);
-    ws.onerror = () => setWsConnected(false);
-
-    ws.onmessage = (event) => {
-      try {
-        const data = JSON.parse(event.data);
-        handleWsMessageRef.current?.(data);
-      } catch { /* ignore */ }
-    };
-
-    return () => { ws.close(); };
-  }, []);
-
   const handleWsMessage = (data: Record<string, unknown>) => {
     const payload = (data.payload || {}) as Record<string, unknown>;
     switch (data.type) {
@@ -378,7 +354,41 @@ function ChatPageInner() {
       }
     }
   };
+
+  // 用 ref 保持 handleWsMessage 始终指向最新版本，避免 stale closure
+  const handleWsMessageRef = useRef(handleWsMessage);
   handleWsMessageRef.current = handleWsMessage;
+
+  useEffect(() => {
+    // 从 cookie 读取 token（Jupyter-lab 风格认证）
+    const cookieMatch = document.cookie.match(/(?:^|; )agentos_token=([^;]*)/);
+    const token = cookieMatch ? decodeURIComponent(cookieMatch[1]) : null;
+    const wsUrl = token ? `${WS_URL}?token=${encodeURIComponent(token)}` : WS_URL;
+
+    let ws: WebSocket | null = null;
+    let cancelled = false;
+
+    // 延迟连接，避免 React Strict Mode 双重执行时第一个连接被立即关闭
+    const timer = setTimeout(() => {
+      if (cancelled) return;
+      ws = new WebSocket(wsUrl);
+      wsRef.current = ws;
+      ws.onopen = () => setWsConnected(true);
+      ws.onclose = () => setWsConnected(false);
+      ws.onerror = () => setWsConnected(false);
+      ws.onmessage = (event) => {
+        try {
+          handleWsMessageRef.current(JSON.parse(event.data));
+        } catch { /* ignore */ }
+      };
+    }, 50);
+
+    return () => {
+      cancelled = true;
+      clearTimeout(timer);
+      if (ws) ws.close();
+    };
+  }, []);
 
   function addMsg(role: ChatMessage['role'], content: string) {
     setMessages(prev => [...prev, { id: makeId(), role, content, timestamp: Date.now() }]);

--- a/agentos/app/web/app/chat/page.tsx
+++ b/agentos/app/web/app/chat/page.tsx
@@ -5,8 +5,7 @@ import { useSearchParams } from 'next/navigation';
 import { Bot, User, Wrench, Send, Plus, RefreshCw, Loader2, ChevronDown, Check } from 'lucide-react';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { SlashCommandMenu, useSlashCommand } from '@/components/chat/SlashCommandMenu';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { authFetch, API_BASE } from '@/lib/authFetch';
 const WS_URL = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8000/ws';
 
 interface ToolInfo {
@@ -182,7 +181,7 @@ function TargetSelector({
   const ref = useRef<HTMLDivElement>(null);
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/agents`).then(r => r.json()).catch(() => []).then(a => setAgents(a));
+    authFetch(`${API_BASE}/api/agents`).then(r => r.json()).catch(() => []).then(a => setAgents(a));
   }, []);
 
   useEffect(() => {
@@ -272,7 +271,7 @@ function ChatPageInner() {
 
   const handleSkillInvoke = async (skillName: string, args: string) => {
     if (!sessionId) return;
-    await fetch(`${API_BASE}/api/sessions/${sessionId}/skill-invoke`, {
+    await authFetch(`${API_BASE}/api/sessions/${sessionId}/skill-invoke`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ skill_name: skillName, arguments: args }),
@@ -394,7 +393,7 @@ function ChatPageInner() {
   const loadSessionList = async () => {
     setLoadingSessions(true);
     try {
-      const res = await fetch(`${API_BASE}/api/sessions`);
+      const res = await authFetch(`${API_BASE}/api/sessions`);
       const d = await res.json();
       setSessions(d.sessions || []);
     } catch { /* ignore */ }
@@ -409,7 +408,7 @@ function ChatPageInner() {
     setIsTyping(false);
     toolCallMapRef.current.clear();
     try {
-      const res = await fetch(`${API_BASE}/api/sessions/${sid}/events`);
+      const res = await authFetch(`${API_BASE}/api/sessions/${sid}/events`);
       const d = await res.json();
       const events = (d.events || []) as Record<string, unknown>[];
       const rebuilt: ChatMessage[] = [];

--- a/agentos/app/web/app/chat/page.tsx
+++ b/agentos/app/web/app/chat/page.tsx
@@ -288,8 +288,7 @@ function ChatPageInner() {
   // ── WebSocket ──
 
   // 用 ref 保持 handleWsMessage 始终指向最新版本，避免 stale closure
-  const handleWsMessageRef = useRef(handleWsMessage);
-  handleWsMessageRef.current = handleWsMessage;
+  const handleWsMessageRef = useRef<((data: Record<string, unknown>) => void) | null>(null);
 
   useEffect(() => {
     // 从 cookie 读取 token（Jupyter-lab 风格认证）
@@ -305,7 +304,7 @@ function ChatPageInner() {
     ws.onmessage = (event) => {
       try {
         const data = JSON.parse(event.data);
-        handleWsMessageRef.current(data);
+        handleWsMessageRef.current?.(data);
       } catch { /* ignore */ }
     };
 
@@ -380,6 +379,7 @@ function ChatPageInner() {
       }
     }
   };
+  handleWsMessageRef.current = handleWsMessage;
 
   function addMsg(role: ChatMessage['role'], content: string) {
     setMessages(prev => [...prev, { id: makeId(), role, content, timestamp: Date.now() }]);

--- a/agentos/app/web/app/gateway/page.tsx
+++ b/agentos/app/web/app/gateway/page.tsx
@@ -5,8 +5,7 @@ import { Loader2, Globe, Settings } from 'lucide-react';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Card, CardContent, CardHeader, CardTitle, CardDescription } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { authFetch, API_BASE } from '@/lib/authFetch';
 
 interface GatewayStats {
   totalChannels: number;
@@ -30,8 +29,8 @@ export default function GatewayPage() {
 
   useEffect(() => {
     Promise.all([
-      fetch(`${API_BASE}/api/gateway/stats`).then(r => r.json()),
-      fetch(`${API_BASE}/api/gateway/channels`).then(r => r.json()),
+      authFetch(`${API_BASE}/api/gateway/stats`).then(r => r.json()),
+      authFetch(`${API_BASE}/api/gateway/channels`).then(r => r.json()),
     ])
       .then(([statsData, channelsData]) => {
         setStats(statsData);

--- a/agentos/app/web/app/sessions/[id]/page.tsx
+++ b/agentos/app/web/app/sessions/[id]/page.tsx
@@ -5,8 +5,7 @@ import { useParams } from 'next/navigation';
 import Link from 'next/link';
 import { ArrowLeft, Bot, User, Wrench, Loader2, AlertCircle, Send } from 'lucide-react';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { authFetch, API_BASE } from '@/lib/authFetch';
 const WS_URL = process.env.NEXT_PUBLIC_WS_URL || 'ws://localhost:8000/ws';
 
 interface Message {
@@ -258,8 +257,8 @@ export default function SessionDetailPage() {
     const fetchData = async () => {
       try {
         const [sessRes, msgRes] = await Promise.all([
-          fetch(`${API_BASE}/api/sessions`),
-          fetch(`${API_BASE}/api/sessions/${sessionId}/messages`),
+          authFetch(`${API_BASE}/api/sessions`),
+          authFetch(`${API_BASE}/api/sessions/${sessionId}/messages`),
         ]);
         const sessData = await sessRes.json();
         const msgData = await msgRes.json();

--- a/agentos/app/web/app/sessions/page.tsx
+++ b/agentos/app/web/app/sessions/page.tsx
@@ -16,8 +16,7 @@ import {
   TableHeader,
   TableRow,
 } from "@/components/ui/table";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { authFetch, API_BASE } from '@/lib/authFetch';
 
 interface Session {
   session_id: string;
@@ -67,7 +66,7 @@ export default function SessionsPage() {
   const [showNewChat, setShowNewChat] = useState(false);
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/sessions`)
+    authFetch(`${API_BASE}/api/sessions`)
       .then(res => res.json())
       .then(data => setSessions(data.sessions || []))
       .catch(() => setSessions([]))
@@ -263,7 +262,7 @@ function NewChatModal({ onClose }: { onClose: () => void }) {
   const [search, setSearch] = useState('');
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/agents`).then(r => r.json()).catch(() => []).then(a => {
+    authFetch(`${API_BASE}/api/agents`).then(r => r.json()).catch(() => []).then(a => {
       setAgents(a);
     }).finally(() => setLoading(false));
   }, []);

--- a/agentos/app/web/app/skills/components/InstalledTab.tsx
+++ b/agentos/app/web/app/skills/components/InstalledTab.tsx
@@ -5,8 +5,7 @@ import { Search, Loader2 } from 'lucide-react';
 import { SkillCard } from './SkillCard';
 import { SkillDetailModal } from './SkillDetailModal';
 import { Input } from '@/components/ui/input';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { authFetch, API_BASE } from '@/lib/authFetch';
 
 interface InstalledSkill {
   id: string;
@@ -42,7 +41,7 @@ export function InstalledTab({ categoryFilter }: InstalledTabProps) {
 
   const fetchSkills = useCallback(async () => {
     try {
-      const res = await fetch(`${API_BASE}/api/skills`);
+      const res = await authFetch(`${API_BASE}/api/skills`);
       const data = await res.json();
       setSkills(data);
     } catch {
@@ -56,7 +55,7 @@ export function InstalledTab({ categoryFilter }: InstalledTabProps) {
 
   // 检查更新
   useEffect(() => {
-    fetch(`${API_BASE}/api/skills/check-updates`, { method: 'POST' })
+    authFetch(`${API_BASE}/api/skills/check-updates`, { method: 'POST' })
       .then(r => r.json())
       .then(data => {
         const updateMap = new Map(
@@ -73,7 +72,7 @@ export function InstalledTab({ categoryFilter }: InstalledTabProps) {
   }, []);
 
   const handleToggle = async (name: string, enabled: boolean) => {
-    await fetch(`${API_BASE}/api/skills/${name}`, {
+    await authFetch(`${API_BASE}/api/skills/${name}`, {
       method: 'PATCH',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ enabled }),
@@ -83,12 +82,12 @@ export function InstalledTab({ categoryFilter }: InstalledTabProps) {
 
   const handleUninstall = async (name: string) => {
     if (!confirm(`确定卸载 ${name}？`)) return;
-    await fetch(`${API_BASE}/api/skills/${name}`, { method: 'DELETE' });
+    await authFetch(`${API_BASE}/api/skills/${name}`, { method: 'DELETE' });
     fetchSkills();
   };
 
   const handleUpdate = async (name: string) => {
-    await fetch(`${API_BASE}/api/skills/${name}/update`, { method: 'POST' });
+    await authFetch(`${API_BASE}/api/skills/${name}/update`, { method: 'POST' });
     fetchSkills();
   };
 

--- a/agentos/app/web/app/skills/components/MarketTab.tsx
+++ b/agentos/app/web/app/skills/components/MarketTab.tsx
@@ -6,8 +6,7 @@ import { SkillCard } from './SkillCard';
 import { SkillDetailModal } from './SkillDetailModal';
 import { Input } from '@/components/ui/input';
 import { Button } from '@/components/ui/button';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { authFetch, API_BASE } from '@/lib/authFetch';
 
 interface MarketSkill {
   id: string;
@@ -179,7 +178,7 @@ export function MarketTab({
     const tid = addToast('loading', `正在安装 ${id}，下载中...`);
 
     try {
-      const res = await fetch(`${API_BASE}/api/skills/install`, {
+      const res = await authFetch(`${API_BASE}/api/skills/install`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ source, id }),
@@ -223,7 +222,7 @@ export function MarketTab({
     setGitInstalling(true);
     const tid = addToast('loading', `正在从 Git 安装，克隆中...`);
     try {
-      const res = await fetch(`${API_BASE}/api/skills/install`, {
+      const res = await authFetch(`${API_BASE}/api/skills/install`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ source: 'git', repo_url: gitUrl }),

--- a/agentos/app/web/app/skills/components/SkillDetailModal.tsx
+++ b/agentos/app/web/app/skills/components/SkillDetailModal.tsx
@@ -2,8 +2,7 @@
 
 import { useEffect, useState } from 'react';
 import { X, FileText, Folder, CheckCircle, XCircle, AlertTriangle } from 'lucide-react';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { authFetch, API_BASE } from '@/lib/authFetch';
 
 interface SkillDetailModalProps {
   source: string;
@@ -41,7 +40,7 @@ export function SkillDetailModal({
   const [loading, setLoading] = useState(true);
 
   useEffect(() => {
-    fetch(`${API_BASE}/api/skills/market/detail?source=${source}&id=${encodeURIComponent(skillId)}`)
+    authFetch(`${API_BASE}/api/skills/market/detail?source=${source}&id=${encodeURIComponent(skillId)}`)
       .then(r => r.json())
       .then(setDetail)
       .catch(() => setDetail(null))

--- a/agentos/app/web/app/tools/page.tsx
+++ b/agentos/app/web/app/tools/page.tsx
@@ -6,8 +6,7 @@ import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Badge } from "@/components/ui/badge";
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { authFetch, API_BASE } from '@/lib/authFetch';
 
 interface Tool {
   id: string;
@@ -36,7 +35,7 @@ export default function ToolsPage() {
   }, []);
 
   const fetchTools = () => {
-    fetch(`${API_BASE}/api/tools`)
+    authFetch(`${API_BASE}/api/tools`)
       .then(res => res.json())
       .then(data => setTools(data))
       .catch(() => setTools([]))
@@ -47,7 +46,7 @@ export default function ToolsPage() {
     const newEnabled = !currentEnabled;
     setTools(prev => prev.map(t => t.name === toolName ? { ...t, enabled: newEnabled } : t));
     try {
-      await fetch(`${API_BASE}/api/tools/${toolName}/enabled`, {
+      await authFetch(`${API_BASE}/api/tools/${toolName}/enabled`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ enabled: newEnabled }),

--- a/agentos/app/web/components/chat/SlashCommandMenu.tsx
+++ b/agentos/app/web/components/chat/SlashCommandMenu.tsx
@@ -1,8 +1,7 @@
 'use client';
 
 import { useState, useEffect, useRef } from 'react';
-
-const API_BASE = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8000';
+import { authFetch, API_BASE } from '@/lib/authFetch';
 
 interface SkillItem {
   name: string;
@@ -22,7 +21,7 @@ export function SlashCommandMenu({ inputValue, onSelect, visible }: SlashCommand
 
   // 加载已启用的 skills
   useEffect(() => {
-    fetch(`${API_BASE}/api/skills`)
+    authFetch(`${API_BASE}/api/skills`)
       .then(r => r.json())
       .then((data: any[]) => {
         setSkills(


### PR DESCRIPTION
## Summary
修复 ui-search 合并后的多个 bug：

- **handleWsMessageRef 初始化顺序** — `const` 不提升，改为函数定义后声明 ref
- **CORS 401 响应头缺失** — auth 中间件返回 401 时附加 CORS 头，OPTIONS 放行
- **前端 plain fetch 无认证** — 全部 10 个页面的 `fetch` 替换为 `authFetch`
- **WebSocket Strict Mode 双重执行** — 延迟 50ms 创建，cancelled 标记防止重复连接
- **切换会话后 agent 回复消失** — 兼容 raw payload `result.content` 和映射后的 `final_response`

## Test plan
- [ ] 打开 chat 页面，WebSocket 正常连接无 console 报错
- [ ] 发送消息，agent 回复正常显示
- [ ] 切换到其他会话再切回来，历史消息完整（包含 agent 回复）
- [ ] auth_enabled=true 时，未认证访问 API 返回 401 带 CORS 头
- [ ] 通过 ?token=xxx 认证后所有页面 API 正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)