### PR TITLE
fix: 配置兼容性 + CLI 命令别名 + MEMORY.md 大小写统一

### DIFF
--- a/agentos/app/cli/commands.py
+++ b/agentos/app/cli/commands.py
@@ -14,7 +14,7 @@ if TYPE_CHECKING:
 # 顶层命令
 TOP_COMMANDS = [
     "/new", "/session", "/agent", "/tool", "/skill",
-    "/history", "/debug", "/help", "/quit",
+    "/history", "/switch", "/cancel", "/debug", "/help", "/quit",
 ]
 
 # 子命令映射
@@ -72,11 +72,15 @@ class CommandDispatcher:
             self.app.console.print(f"[green]✓ 新会话: {sid} (Agent: {arg or 'default'})[/green]")
         elif cmd == "/session":
             await self._handle_session(arg.strip(), arg2.strip())
+        elif cmd == "/switch":
+            await self._handle_session("switch", arg.strip())
         elif cmd in ("/history", "/h"):
             await self.app._send_query({
                 "type": "get_messages",
                 "payload": {"session_id": self.app.current_session_id},
             })
+        elif cmd == "/cancel":
+            await self._cancel_turn()
 
         # ── Agent 管理 ──────────────────────────────
         elif cmd == "/agent":
@@ -126,6 +130,19 @@ class CommandDispatcher:
   /session list                 列出历史会话
   /session switch <id>          切换会话
   /session current              当前会话信息""")
+
+    async def _cancel_turn(self) -> None:
+        """兼容 /cancel 命令，向后端发送取消请求。"""
+        if not self.app.current_session_id:
+            self.app.console.print("[yellow]当前没有可取消的会话[/yellow]")
+            return
+        if hasattr(self.app, "_turn_cancelled"):
+            self.app._turn_cancelled = True
+        await self.app._send({
+            "type": "cancel_turn",
+            "session_id": self.app.current_session_id,
+            "payload": {"reason": "user_cancel"},
+        })
 
     # ── Agent 子命令 ──────────────────────────────
 

--- a/agentos/capabilities/memory/manager.py
+++ b/agentos/capabilities/memory/manager.py
@@ -62,12 +62,14 @@ class MemoryManager:
         """
         parts: list[str] = []
 
-        memory_path = Path(self.workspace_dir) / "MEMORY.md"
-        if memory_path.exists():
+        for memory_path in self._global_memory_candidates():
+            if not memory_path.exists():
+                continue
             try:
                 content = await asyncio.to_thread(memory_path.read_text, "utf-8")
                 if content.strip():
                     parts.append(content.strip())
+                    break
             except Exception:
                 logger.warning("读取 MEMORY.md 失败", exc_info=True)
 
@@ -139,9 +141,10 @@ class MemoryManager:
         memory_files: dict[str, Path] = {}
 
         # MEMORY.md
-        memory_md = workspace / "MEMORY.md"
-        if memory_md.exists():
-            memory_files["MEMORY.md"] = memory_md
+        for memory_md in self._global_memory_candidates():
+            if memory_md.exists():
+                memory_files["MEMORY.md"] = memory_md
+                break
 
         # memory/*.md
         memory_dir = workspace / "memory"
@@ -300,8 +303,15 @@ class MemoryManager:
         """调用 LLM 对当前对话进行摘要。"""
         from agentos.platform.config.config import config
 
-        provider_name = provider_name or config.get("agent.provider", "mock")
-        model = model or config.get("agent.default_model")
+        if not model:
+            model = (
+                config.get("agent.model")
+                or config.get("agent.default_model")
+                or config.get("llm.default_model")
+            )
+        resolved_provider, resolved_model = config.resolve_model(model)
+        provider_name = provider_name or resolved_provider
+        model = resolved_model
 
         provider = self.llm_factory.get_provider(provider_name)
         response = await provider.call(
@@ -321,12 +331,14 @@ class MemoryManager:
         if agent_id:
             memory_path = Path(self.workspace_dir) / "memory" / f"{agent_id}.md"
         else:
-            memory_path = Path(self.workspace_dir) / "memory.md"
+            memory_path = Path(self.workspace_dir) / "MEMORY.md"
 
         timestamp = datetime.now().strftime("%Y-%m-%d %H:%M:%S")
         entry = f"\n\n---\n[{timestamp}]\n{summary}\n"
 
         try:
+            if not agent_id:
+                await asyncio.to_thread(self._migrate_legacy_memory_file, memory_path)
             await asyncio.to_thread(self._append_file_blocking, memory_path, entry)
             logger.info("对话总结已追加到 %s", memory_path)
         except Exception:
@@ -338,6 +350,16 @@ class MemoryManager:
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "a", encoding="utf-8") as file:
             file.write(content)
+
+    def _global_memory_candidates(self) -> list[Path]:
+        workspace = Path(self.workspace_dir)
+        return [workspace / "MEMORY.md", workspace / "memory.md"]
+
+    @staticmethod
+    def _migrate_legacy_memory_file(target: Path) -> None:
+        legacy = target.parent / "memory.md"
+        if legacy.exists() and not target.exists():
+            legacy.rename(target)
 
     def _format_memory_prompt(self, content: str) -> str:
         """将 MEMORY.md 内容包装为 system prompt 片段

--- a/agentos/kernel/runtime/context_builder.py
+++ b/agentos/kernel/runtime/context_builder.py
@@ -159,7 +159,11 @@ class ContextBuilder:
         model_key = (
             agent_config.model
             if agent_config and agent_config.model
-            else config.get("agent.model") or config.get("llm.default_model", "mock")
+            else (
+                config.get("agent.model")
+                or config.get("agent.default_model")
+                or config.get("llm.default_model", "mock")
+            )
         )
         _, model = config.resolve_model(model_key)
         return RuntimeInfo(

--- a/agentos/kernel/runtime/workers/agent_worker.py
+++ b/agentos/kernel/runtime/workers/agent_worker.py
@@ -72,7 +72,11 @@ class AgentSessionWorker(SessionWorker):
         """获取 model key（llm.models 中的 key）"""
         if self.agent_config and self.agent_config.model:
             return self.agent_config.model
-        return config.get("agent.model") or config.get("llm.default_model", "mock")
+        return (
+            config.get("agent.model")
+            or config.get("agent.default_model")
+            or config.get("llm.default_model", "mock")
+        )
 
     def _get_temperature(self) -> float:
         if self.agent_config:

--- a/tests/e2e/run_ask_user_real_api.py
+++ b/tests/e2e/run_ask_user_real_api.py
@@ -116,7 +116,7 @@ async def _run(args: argparse.Namespace) -> int:
     saw_error = ERROR_RAISED in event_types
 
     print("\n=== 回归摘要 ===")
-    print(f"provider={args.provider} model={args.model or config.get('agent.default_model')}")
+    print(f"provider={args.provider} model={args.model or config.get('agent.model') or config.get('llm.default_model')}")
     print(f"elapsed={elapsed:.2f}s")
     print(f"user.question_asked={saw_question_asked}")
     print(f"user.question_answered={saw_question_answered}")

--- a/tests/e2e/run_e2e.py
+++ b/tests/e2e/run_e2e.py
@@ -171,13 +171,13 @@ async def setup_services(tmp_dir: Path, provider: str, model: str | None):
     config.data["system"]["log_level"] = "DEBUG"
 
     if provider == "mock":
-        config.data["agent"]["provider"] = "mock"
-        config.data["agent"]["default_model"] = "mock-agent-v1"
+        config.data["agent"]["model"] = "mock"
+        config.data["llm"]["default_model"] = "mock"
         config.data["tools"]["serper_search"]["api_key"] = ""
     else:
-        config.data["agent"]["provider"] = provider
         if model:
-            config.data["agent"]["default_model"] = model
+            config.data["agent"]["model"] = model
+            config.data["llm"]["default_model"] = model
 
     setup_logging()
 

--- a/tests/e2e/test_gateway_integration.py
+++ b/tests/e2e/test_gateway_integration.py
@@ -31,15 +31,15 @@ from tests.conftest import load_gemini_config, skip_if_gemini_unavailable
 def _apply_provider_config(provider_name: str) -> None:
     """根据 provider_name 配置全局 config。"""
     if provider_name == "mock":
-        config.data["agent"]["provider"] = "mock"
-        config.data["agent"]["default_model"] = "mock-agent-v1"
+        config.data["agent"]["model"] = "mock"
+        config.data["llm"]["default_model"] = "mock"
     else:
         gemini_cfg = load_gemini_config()
-        config.data["agent"]["provider"] = "gemini"
-        config.data["agent"]["default_model"] = gemini_cfg["default_model"]
-        # 将 gemini provider 配置写入 llm_providers
-        config.data["llm_providers"]["gemini"] = {
-            **config.data["llm_providers"].get("gemini", {}),
+        config.data["agent"]["model"] = "gemini_pro"
+        config.data["llm"]["default_model"] = "gemini_pro"
+        # 将 gemini provider 配置写入 llm.providers
+        config.data["llm"]["providers"]["gemini"] = {
+            **config.data["llm"]["providers"].get("gemini", {}),
             **gemini_cfg,
         }
 

--- a/tests/e2e/test_memory_turn_summary_flow.py
+++ b/tests/e2e/test_memory_turn_summary_flow.py
@@ -37,7 +37,7 @@ async def test_completed_turn_appends_summary_to_memory_file(tmp_path: Path) -> 
             timeout=10,
         )
 
-        memory_path = workspace / "memory.md"
+        memory_path = workspace / "MEMORY.md"
         for _ in range(20):
             if memory_path.exists():
                 break

--- a/tests/e2e/test_websocket_flow.py
+++ b/tests/e2e/test_websocket_flow.py
@@ -30,17 +30,17 @@ from tests.conftest import load_gemini_config, skip_if_gemini_unavailable
 def _apply_provider_config(provider_name: str) -> None:
     """根据 provider_name 配置全局 config。"""
     if provider_name == "mock":
-        config.data["agent"]["provider"] = "mock"
-        config.data["agent"]["default_model"] = "mock-agent-v1"
-        config.data["agent"]["default_temperature"] = 0.2
+        config.data["agent"]["model"] = "mock"
+        config.data["llm"]["default_model"] = "mock"
+        config.data["agent"]["temperature"] = 0.2
         config.data["tools"]["serper_search"]["api_key"] = ""
     else:
         gemini_cfg = load_gemini_config()
-        config.data["agent"]["provider"] = "gemini"
-        config.data["agent"]["default_model"] = gemini_cfg["default_model"]
-        config.data["agent"]["default_temperature"] = 0.2
-        config.data["llm_providers"]["gemini"] = {
-            **config.data["llm_providers"].get("gemini", {}),
+        config.data["agent"]["model"] = "gemini_pro"
+        config.data["llm"]["default_model"] = "gemini_pro"
+        config.data["agent"]["temperature"] = 0.2
+        config.data["llm"]["providers"]["gemini"] = {
+            **config.data["llm"]["providers"].get("gemini", {}),
             **gemini_cfg,
         }
 

--- a/tests/e2e/test_whatsapp_channel_e2e.py
+++ b/tests/e2e/test_whatsapp_channel_e2e.py
@@ -69,8 +69,8 @@ async def test_whatsapp_channel_end_to_end_flow(tmp_path: Path) -> None:
     config.data["system"]["workspace_dir"] = str(workspace)
     config.data["system"]["agentos_home"] = str(agentos_home)
     config.data["system"]["log_level"] = "DEBUG"
-    config.data["agent"]["provider"] = "mock"
-    config.data["agent"]["default_model"] = "mock-agent-v1"
+    config.data["agent"]["model"] = "mock"
+    config.data["llm"]["default_model"] = "mock"
 
     setup_logging()
 

--- a/tests/unit/test_agent_worker.py
+++ b/tests/unit/test_agent_worker.py
@@ -2,6 +2,7 @@
 from __future__ import annotations
 
 import asyncio
+import copy
 import json
 from unittest.mock import AsyncMock
 
@@ -30,6 +31,7 @@ from agentos.kernel.events.types import (
 from agentos.kernel.runtime.context_builder import ContextBuilder
 from agentos.kernel.runtime.state import SessionStateStore, TurnState
 from agentos.kernel.runtime.workers.agent_worker import AgentSessionWorker
+from agentos.platform.config.config import config
 
 
 # ── 真实 AgentRuntime 替身 ────────────────────────────────
@@ -149,6 +151,17 @@ class TestConfigHelpers:
         worker = AgentSessionWorker("s1", private_bus, runtime, agent_config=None)
         temp = worker._get_temperature()
         assert isinstance(temp, (int, float))
+
+    def test_get_model_key_fallback_to_legacy_agent_default_model(self, private_bus, runtime):
+        original = copy.deepcopy(config.data)
+        try:
+            config.data["agent"]["model"] = ""
+            config.data["agent"]["default_model"] = "mock-agent-v1"
+            worker = AgentSessionWorker("s1", private_bus, runtime, agent_config=None)
+            assert worker._get_model() == "mock-agent-v1"
+            assert worker._get_provider() == "mock"
+        finally:
+            config.data = original
 
     def test_get_filtered_tools_no_config(self, private_bus, runtime):
         """无 agent_config 时返回全部工具"""

--- a/tests/unit/test_anthropic_provider.py
+++ b/tests/unit/test_anthropic_provider.py
@@ -43,6 +43,10 @@ def real_config() -> Config:
 @pytest.fixture(scope="module")
 def provider(real_config: Config) -> Any:
     """使用真实配置创建 AnthropicProvider 实例"""
+    api_key = real_config.get("llm.providers.anthropic.api_key", "")
+    if not api_key:
+        pytest.skip("未配置 Anthropic API key，跳过真实 API 测试")
+
     # 临时替换全局 config，让 AnthropicProvider.__init__ 能读取到真实配置
     import agentos.adapters.llm.providers.anthropic_provider as mod
     original_config = mod.config
@@ -58,7 +62,7 @@ def provider(real_config: Config) -> Any:
 @pytest.fixture(scope="module")
 def model(real_config: Config) -> str:
     """从配置中获取默认模型"""
-    return real_config.get("llm_providers.anthropic.default_model", "claude-opus-4-6")
+    return real_config.get("llm.models.claude_opus.model_id", "claude-opus-4-6")
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_cli_app_unit.py
+++ b/tests/unit/test_cli_app_unit.py
@@ -72,10 +72,10 @@ async def _create_ws_server(tmp_path, provider_name: str = "mock"):
     # 配置 provider
     if provider_name == "gemini":
         gemini_cfg = load_gemini_config()
-        cfg.set("agent.provider", "gemini")
-        cfg.set("agent.default_model", gemini_cfg["default_model"])
-        cfg.data["llm_providers"]["gemini"] = {
-            **cfg.data["llm_providers"].get("gemini", {}),
+        cfg.set("agent.model", "gemini_pro")
+        cfg.set("llm.default_model", "gemini_pro")
+        cfg.data["llm"]["providers"]["gemini"] = {
+            **cfg.data["llm"]["providers"].get("gemini", {}),
             **gemini_cfg,
         }
     # mock 使用默认配置即可（Config 默认就是 mock）

--- a/tests/unit/test_cli_commands.py
+++ b/tests/unit/test_cli_commands.py
@@ -59,6 +59,19 @@ class TestCommandDispatcher:
         await d.dispatch("/new helper")
         assert app.current_agent_id == "helper"
 
+    async def test_switch_top_level_alias(self):
+        app = MockCLIApp()
+        d = CommandDispatcher(app)
+        await d.dispatch("/switch s123")
+        assert app.current_session_id == "s123"
+
+    async def test_cancel_top_level_alias(self):
+        app = MockCLIApp()
+        app.current_session_id = "s1"
+        d = CommandDispatcher(app)
+        await d.dispatch("/cancel")
+        assert any(m.get("type") == "cancel_turn" for m in app._sent)
+
     # ── /session 命令 ──────────────────────────
 
     async def test_session_list(self):

--- a/tests/unit/test_memory_system.py
+++ b/tests/unit/test_memory_system.py
@@ -441,6 +441,38 @@ class TestMemoryManager:
         # BM25 可能返回结果也可能为空（取决于 FTS5 支持），不应崩溃
         assert isinstance(results, list)
 
+    @pytest.mark.asyncio
+    async def test_summarize_turn_appends_to_uppercase_memory_md(self, workspace, tmp_path):
+        from agentos.capabilities.memory.manager import MemoryManager
+
+        class _FakeProvider:
+            async def call(self, **kwargs):
+                return {"content": "用户偏好 Python"}
+
+        class _FakeFactory:
+            def get_provider(self, provider_name=None):
+                return _FakeProvider()
+
+        manager = MemoryManager(
+            workspace_dir=str(workspace),
+            config=MemoryConfig(enabled=True),
+            db_path=tmp_path / "test_memory_summary.db",
+            llm_factory=_FakeFactory(),
+        )
+
+        await manager.summarize_turn(
+            messages=[
+                {"role": "user", "content": "请记住我偏好 Python"},
+                {"role": "assistant", "content": "好的，我会记住。"},
+            ]
+        )
+
+        assert (workspace / "MEMORY.md").exists()
+        assert not (workspace / "memory.md").exists()
+
+        content = (workspace / "MEMORY.md").read_text(encoding="utf-8")
+        assert "用户偏好 Python" in content
+
 
 # ===== MemorySearchTool 测试 =====
 

--- a/tests/unit/test_orchestration_tool.py
+++ b/tests/unit/test_orchestration_tool.py
@@ -118,7 +118,7 @@ class TestExecuteSuccess:
         assert registered.name == "New Agent"
 
         # 验证已持久化到磁盘
-        saved_file = agent_registry._config_dir / "new-agent.json"
+        saved_file = agent_registry._config_dir / "new-agent" / "config.json"
         assert saved_file.exists()
 
     async def test_inherit_from_default(self, tool, registry_with_default):


### PR DESCRIPTION
## Summary

### 配置兼容性
- `agent_worker`/`context_builder` model key 回退链增加 `agent.default_model`（旧配置兼容）
- `memory manager` 使用 `config.resolve_model()` 替代旧的 `agent.provider`/`agent.default_model`
- 全部 e2e/unit 测试适配新配置路径（`llm.providers`/`agent.model`/`llm.default_model`）

### CLI
- 新增 `/switch` 顶层命令别名（等同 `/session switch`）
- 新增 `/cancel` 顶层命令（取消当前对话轮次）

### Memory
- `MEMORY.md` 统一为大写文件名
- 兼容读取旧 `memory.md`，首次写入时自动迁移

### 测试
- 新增 legacy config fallback 测试
- 新增 `/switch`、`/cancel` 命令测试
- 新增 `MEMORY.md` 大写文件名测试
- `orchestration tool` 持久化路径修复（`new-agent/config.json`）
- `anthropic provider` 无 API key 时自动 skip

## Test plan
- [x] 770 passed, 0 failed, 33 skipped

🤖 Generated with [Claude Code](https://claude.com/claude-code)