### PR TITLE
feat: Settings 页面 + Agent 模型下拉选择

### DIFF
--- a/agentos/app/web/app/agents/[id]/page.tsx
+++ b/agentos/app/web/app/agents/[id]/page.tsx
@@ -60,10 +60,9 @@ export default function AgentDetailPage() {
   // Per-agent config 编辑状态
   const [editName, setEditName] = useState('');
   const [editDesc, setEditDesc] = useState('');
-  const [editProvider, setEditProvider] = useState('');
   const [editModel, setEditModel] = useState('');
   const [editTemp, setEditTemp] = useState('0.2');
-  const [editMaxTokens, setEditMaxTokens] = useState('');
+  const [availableModels, setAvailableModels] = useState<string[]>([]);
   const [editPrompt, setEditPrompt] = useState('');
   const [editDelegateTo, setEditDelegateTo] = useState<string[]>([]);
   const [editMaxDepth, setEditMaxDepth] = useState('3');
@@ -82,10 +81,8 @@ export default function AgentDetailPage() {
         // 初始化编辑状态
         setEditName(data.name || '');
         setEditDesc(data.description || '');
-        setEditProvider(data.provider || '');
         setEditModel(data.model || '');
         setEditTemp(String(data.temperature ?? 0.2));
-        setEditMaxTokens(data.maxTokens ? String(data.maxTokens) : '');
         setEditPrompt(data.systemPrompt || '');
         setEditDelegateTo(data.canDelegateTo || []);
         setEditMaxDepth(String(data.maxDelegationDepth ?? 3));
@@ -103,13 +100,22 @@ export default function AgentDetailPage() {
 
   useEffect(() => { loadAgent(); }, [loadAgent]);
 
-  // 加载所有 agent 列表（用于委托配置）
+  // 加载所有 agent 列表（用于委托配置）和可用模型列表
   useEffect(() => {
     if (activeTab === 'config') {
       authFetch(`${API_BASE}/api/agents`)
         .then(res => res.json())
         .then(data => setAllAgents(data.map((a: AgentSummary) => ({ id: a.id, name: a.name }))))
         .catch(() => setAllAgents([]));
+      authFetch(`${API_BASE}/api/config/sections`)
+        .then(res => res.json())
+        .then(data => {
+          const models = data?.llm?.models;
+          if (models && typeof models === 'object') {
+            setAvailableModels(Object.keys(models).filter(k => k !== 'mock'));
+          }
+        })
+        .catch(() => setAvailableModels([]));
     }
   }, [activeTab]);
 
@@ -121,14 +127,12 @@ export default function AgentDetailPage() {
       const body: Record<string, unknown> = {
         name: editName,
         description: editDesc,
-        provider: editProvider || undefined,
         model: editModel || undefined,
         temperature: parseFloat(editTemp) || 0.2,
         systemPrompt: editPrompt,
         can_delegate_to: editDelegateTo,
         max_delegation_depth: parseInt(editMaxDepth) || 3,
       };
-      if (editMaxTokens) body.max_tokens = parseInt(editMaxTokens) || undefined;
       const res = await authFetch(`${API_BASE}/api/agents/${agentId}/config`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
@@ -328,13 +332,22 @@ export default function AgentDetailPage() {
                     </div>
                   </ConfigSection>
 
-                  <ConfigSection title="LLM Backend" desc="Model provider and generation parameters" expanded={expandedSections.llm}
+                  <ConfigSection title="LLM Backend" desc="Model selection and generation parameters" expanded={expandedSections.llm}
                     onToggle={() => setExpandedSections(p => ({ ...p, llm: !p.llm }))}>
                     <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                      <CfgInput label="Provider" value={editProvider} onChange={setEditProvider} />
-                      <CfgInput label="Model" value={editModel} onChange={setEditModel} />
+                      <div className="space-y-1.5">
+                        <label className="text-muted-foreground text-sm font-semibold">Model</label>
+                        <select value={editModel} onChange={e => setEditModel(e.target.value)}
+                          className="w-full bg-background border border-input rounded-xl px-4 py-2.5 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all shadow-sm appearance-none cursor-pointer">
+                          {!availableModels.includes(editModel) && editModel && (
+                            <option value={editModel}>{editModel}</option>
+                          )}
+                          {availableModels.map(m => (
+                            <option key={m} value={m}>{m}</option>
+                          ))}
+                        </select>
+                      </div>
                       <CfgInput label="Temperature" type="number" value={editTemp} onChange={setEditTemp} />
-                      <CfgInput label="Max Tokens" type="number" value={editMaxTokens} onChange={setEditMaxTokens} />
                     </div>
                   </ConfigSection>
 

--- a/agentos/app/web/app/settings/page.tsx
+++ b/agentos/app/web/app/settings/page.tsx
@@ -1,0 +1,388 @@
+'use client';
+
+import { useState, useEffect } from 'react';
+import { Loader2, Save, Plus, Trash2, ChevronDown, ChevronRight, Server, Cpu, Settings2 } from 'lucide-react';
+import { DashboardLayout } from '@/components/layout/DashboardLayout';
+import { authFetch, API_BASE } from '@/lib/authFetch';
+
+interface ProviderConfig {
+  api_key: string;
+  base_url: string;
+  timeout: number;
+  max_retries: number;
+}
+
+interface ModelConfig {
+  provider: string;
+  model_id: string;
+  timeout: number;
+  max_output_tokens: number;
+}
+
+export default function SettingsPage() {
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [saveMsg, setSaveMsg] = useState('');
+
+  // LLM 配置
+  const [providers, setProviders] = useState<Record<string, ProviderConfig>>({});
+  const [models, setModels] = useState<Record<string, ModelConfig>>({});
+  const [defaultModel, setDefaultModel] = useState('');
+
+  // 展开状态
+  const [expandedSections, setExpandedSections] = useState<Record<string, boolean>>({
+    providers: true, models: true, general: true,
+  });
+  const [expandedProviders, setExpandedProviders] = useState<Record<string, boolean>>({});
+  const [expandedModels, setExpandedModels] = useState<Record<string, boolean>>({});
+
+  // 新建表单
+  const [showNewProvider, setShowNewProvider] = useState(false);
+  const [newProviderName, setNewProviderName] = useState('');
+  const [showNewModel, setShowNewModel] = useState(false);
+  const [newModelName, setNewModelName] = useState('');
+
+  // 加载配置
+  useEffect(() => {
+    authFetch(`${API_BASE}/api/config/sections`)
+      .then(res => res.json())
+      .then(data => {
+        const llm = data?.llm || {};
+        const p = llm.providers || {};
+        // 过滤掉 mock provider
+        const { mock, ...realProviders } = p;
+        setProviders(realProviders);
+        const m = llm.models || {};
+        const { mock: mockModel, ...realModels } = m;
+        setModels(realModels);
+        setDefaultModel(llm.default_model || '');
+      })
+      .catch(() => {})
+      .finally(() => setLoading(false));
+  }, []);
+
+  // 保存配置
+  const saveConfig = async () => {
+    setSaving(true);
+    setSaveMsg('');
+    try {
+      // 重新组装完整的 llm section（包含 mock）
+      const llm = {
+        providers: { mock: { api_key: '', base_url: '', timeout: 60, max_retries: 1 }, ...providers },
+        models: { mock: { provider: 'mock', model_id: 'mock-agent-v1' }, ...models },
+        default_model: defaultModel,
+      };
+      const res = await authFetch(`${API_BASE}/api/config/sections`, {
+        method: 'PUT',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ llm }),
+      });
+      if (res.ok) {
+        setSaveMsg('已保存');
+      } else {
+        const err = await res.json().catch(() => ({}));
+        setSaveMsg(err.detail || '保存失败');
+      }
+    } catch {
+      setSaveMsg('保存失败');
+    } finally {
+      setSaving(false);
+      setTimeout(() => setSaveMsg(''), 3000);
+    }
+  };
+
+  // Provider 操作
+  const updateProvider = (name: string, field: keyof ProviderConfig, value: string | number) => {
+    setProviders(prev => ({
+      ...prev,
+      [name]: { ...prev[name], [field]: value },
+    }));
+  };
+
+  const removeProvider = (name: string) => {
+    if (!confirm(`确定删除 provider "${name}" 吗？关联的模型配置不会自动删除。`)) return;
+    setProviders(prev => {
+      const next = { ...prev };
+      delete next[name];
+      return next;
+    });
+  };
+
+  const addProvider = () => {
+    const name = newProviderName.trim().toLowerCase();
+    if (!name || providers[name]) return;
+    setProviders(prev => ({
+      ...prev,
+      [name]: { api_key: '', base_url: '', timeout: 60, max_retries: 3 },
+    }));
+    setExpandedProviders(prev => ({ ...prev, [name]: true }));
+    setNewProviderName('');
+    setShowNewProvider(false);
+  };
+
+  // Model 操作
+  const updateModel = (name: string, field: keyof ModelConfig, value: string | number) => {
+    setModels(prev => ({
+      ...prev,
+      [name]: { ...prev[name], [field]: value },
+    }));
+  };
+
+  const removeModel = (name: string) => {
+    if (!confirm(`确定删除模型 "${name}" 吗？`)) return;
+    setModels(prev => {
+      const next = { ...prev };
+      delete next[name];
+      return next;
+    });
+    if (defaultModel === name) setDefaultModel('');
+  };
+
+  const addModel = () => {
+    const name = newModelName.trim();
+    if (!name || models[name]) return;
+    const firstProvider = Object.keys(providers)[0] || '';
+    setModels(prev => ({
+      ...prev,
+      [name]: { provider: firstProvider, model_id: '', timeout: 60, max_output_tokens: 8192 },
+    }));
+    setExpandedModels(prev => ({ ...prev, [name]: true }));
+    setNewModelName('');
+    setShowNewModel(false);
+  };
+
+  const maskApiKey = (key: string) => {
+    if (!key || key.startsWith('${')) return key;
+    if (key.length <= 8) return '••••••••';
+    return key.slice(0, 4) + '••••••••' + key.slice(-4);
+  };
+
+  const providerNames = Object.keys(providers);
+  const modelNames = Object.keys(models);
+
+  if (loading) {
+    return (
+      <DashboardLayout>
+        <div className="flex flex-col items-center justify-center h-full gap-4 text-muted-foreground">
+          <Loader2 className="animate-spin text-primary" size={40} />
+          <p className="text-sm font-medium">Loading settings...</p>
+        </div>
+      </DashboardLayout>
+    );
+  }
+
+  return (
+    <DashboardLayout>
+      <div className="h-full flex flex-col bg-background">
+        {/* Header */}
+        <div className="bg-card/50 backdrop-blur-sm border-b border-border p-6 sticky top-0 z-20 shadow-sm">
+          <div className="flex items-center justify-between">
+            <div>
+              <h1 className="text-2xl font-bold text-foreground tracking-tight flex items-center gap-3">
+                <Settings2 size={28} className="text-primary" />
+                LLM Settings
+              </h1>
+              <p className="text-base text-muted-foreground mt-1.5">Manage LLM providers, models, and default configuration.</p>
+            </div>
+            <div className="flex items-center gap-4">
+              {saveMsg && (
+                <span className={`text-sm font-semibold px-3 py-1.5 rounded-full border shadow-sm ${
+                  saveMsg.includes('失败')
+                    ? 'text-destructive bg-destructive/10 border-destructive/20'
+                    : 'text-green-600 bg-green-500/10 border-green-500/20 dark:text-green-400'
+                }`}>
+                  {saveMsg}
+                </span>
+              )}
+              <button onClick={saveConfig} disabled={saving}
+                className="flex items-center gap-2.5 px-6 py-2.5 bg-primary text-primary-foreground font-bold rounded-xl hover:bg-primary/90 disabled:opacity-50 shadow-lg active:scale-95 transition-all">
+                {saving ? <Loader2 size={18} className="animate-spin" /> : <Save size={18} />}
+                Save All
+              </button>
+            </div>
+          </div>
+        </div>
+
+        {/* Content */}
+        <div className="flex-1 overflow-auto p-8 lg:p-10">
+          <div className="max-w-6xl mx-auto space-y-8">
+
+            {/* Default Model */}
+            <Section title="General" desc="Global LLM defaults" icon={<Settings2 size={18} />}
+              expanded={expandedSections.general} onToggle={() => setExpandedSections(p => ({ ...p, general: !p.general }))}>
+              <div className="max-w-md">
+                <label className="text-muted-foreground text-sm font-semibold block mb-2">Default Model</label>
+                <select value={defaultModel} onChange={e => setDefaultModel(e.target.value)}
+                  className="w-full bg-background border border-input rounded-xl px-4 py-2.5 text-base text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all shadow-sm appearance-none cursor-pointer">
+                  {modelNames.map(m => (
+                    <option key={m} value={m}>{m}</option>
+                  ))}
+                </select>
+                <p className="mt-2 text-xs text-muted-foreground">Used when an agent does not specify a model.</p>
+              </div>
+            </Section>
+
+            {/* Providers */}
+            <Section title="Providers" desc={`${providerNames.length} configured`} icon={<Server size={18} />}
+              expanded={expandedSections.providers} onToggle={() => setExpandedSections(p => ({ ...p, providers: !p.providers }))}>
+              <div className="space-y-4">
+                {providerNames.map(name => (
+                  <div key={name} className="bg-background border border-border rounded-xl overflow-hidden">
+                    <button onClick={() => setExpandedProviders(p => ({ ...p, [name]: !p[name] }))}
+                      className="w-full flex items-center gap-3 px-5 py-4 hover:bg-muted/30 transition-all text-left group">
+                      <div className={`p-1 rounded-lg transition-all ${expandedProviders[name] ? 'text-primary' : 'text-muted-foreground'}`}>
+                        {expandedProviders[name] ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+                      </div>
+                      <span className="text-sm font-bold text-foreground flex-1">{name}</span>
+                      <span className="text-xs text-muted-foreground font-mono">
+                        {providers[name]?.api_key ? maskApiKey(providers[name].api_key) : 'No key'}
+                      </span>
+                      <button onClick={e => { e.stopPropagation(); removeProvider(name); }}
+                        className="opacity-0 group-hover:opacity-100 p-1.5 rounded-lg hover:bg-destructive/10 text-destructive/40 hover:text-destructive transition-all">
+                        <Trash2 size={14} />
+                      </button>
+                    </button>
+                    {expandedProviders[name] && (
+                      <div className="px-5 pb-5 pt-2 border-t border-border/40">
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                          <FieldInput label="API Key" value={providers[name]?.api_key || ''} type="password"
+                            onChange={v => updateProvider(name, 'api_key', v)} />
+                          <FieldInput label="Base URL" value={providers[name]?.base_url || ''}
+                            onChange={v => updateProvider(name, 'base_url', v)} />
+                          <FieldInput label="Timeout (s)" value={String(providers[name]?.timeout || 60)} type="number"
+                            onChange={v => updateProvider(name, 'timeout', parseInt(v) || 60)} />
+                          <FieldInput label="Max Retries" value={String(providers[name]?.max_retries || 3)} type="number"
+                            onChange={v => updateProvider(name, 'max_retries', parseInt(v) || 3)} />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+
+                {showNewProvider ? (
+                  <div className="flex gap-2 p-1 bg-muted/30 rounded-xl border border-border shadow-sm">
+                    <input type="text" value={newProviderName} onChange={e => setNewProviderName(e.target.value)}
+                      placeholder="provider name (e.g. openai)"
+                      className="flex-1 bg-background border-none rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary/20 transition-all"
+                      onKeyDown={e => e.key === 'Enter' && addProvider()} autoFocus />
+                    <button onClick={addProvider} className="px-3 py-2 bg-primary text-primary-foreground text-xs font-bold rounded-lg hover:bg-primary/90 shadow-sm">Add</button>
+                    <button onClick={() => { setShowNewProvider(false); setNewProviderName(''); }}
+                      className="px-3 py-2 text-xs font-bold rounded-lg hover:bg-muted text-muted-foreground">Cancel</button>
+                  </div>
+                ) : (
+                  <button onClick={() => setShowNewProvider(true)}
+                    className="flex items-center gap-2 px-4 py-3 text-sm font-semibold text-primary hover:bg-primary/5 rounded-xl border border-dashed border-primary/30 transition-all w-full justify-center">
+                    <Plus size={16} />
+                    Add Provider
+                  </button>
+                )}
+              </div>
+            </Section>
+
+            {/* Models */}
+            <Section title="Models" desc={`${modelNames.length} configured`} icon={<Cpu size={18} />}
+              expanded={expandedSections.models} onToggle={() => setExpandedSections(p => ({ ...p, models: !p.models }))}>
+              <div className="space-y-4">
+                {modelNames.map(name => (
+                  <div key={name} className="bg-background border border-border rounded-xl overflow-hidden">
+                    <button onClick={() => setExpandedModels(p => ({ ...p, [name]: !p[name] }))}
+                      className="w-full flex items-center gap-3 px-5 py-4 hover:bg-muted/30 transition-all text-left group">
+                      <div className={`p-1 rounded-lg transition-all ${expandedModels[name] ? 'text-primary' : 'text-muted-foreground'}`}>
+                        {expandedModels[name] ? <ChevronDown size={16} /> : <ChevronRight size={16} />}
+                      </div>
+                      <span className="text-sm font-bold text-foreground flex-1">{name}</span>
+                      <span className="text-xs text-muted-foreground font-mono">{models[name]?.provider} / {models[name]?.model_id}</span>
+                      {defaultModel === name && (
+                        <span className="text-[10px] font-bold text-primary bg-primary/10 px-2 py-0.5 rounded-full border border-primary/20">DEFAULT</span>
+                      )}
+                      <button onClick={e => { e.stopPropagation(); removeModel(name); }}
+                        className="opacity-0 group-hover:opacity-100 p-1.5 rounded-lg hover:bg-destructive/10 text-destructive/40 hover:text-destructive transition-all">
+                        <Trash2 size={14} />
+                      </button>
+                    </button>
+                    {expandedModels[name] && (
+                      <div className="px-5 pb-5 pt-2 border-t border-border/40">
+                        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                          <div className="space-y-1.5">
+                            <label className="text-muted-foreground text-xs font-semibold">Provider</label>
+                            <select value={models[name]?.provider || ''} onChange={e => updateModel(name, 'provider', e.target.value)}
+                              className="w-full bg-background border border-input rounded-xl px-4 py-2.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all shadow-sm appearance-none cursor-pointer">
+                              {providerNames.map(p => (
+                                <option key={p} value={p}>{p}</option>
+                              ))}
+                            </select>
+                          </div>
+                          <FieldInput label="Model ID" value={models[name]?.model_id || ''}
+                            onChange={v => updateModel(name, 'model_id', v)} />
+                          <FieldInput label="Timeout (s)" value={String(models[name]?.timeout || 60)} type="number"
+                            onChange={v => updateModel(name, 'timeout', parseInt(v) || 60)} />
+                          <FieldInput label="Max Output Tokens" value={String(models[name]?.max_output_tokens || 8192)} type="number"
+                            onChange={v => updateModel(name, 'max_output_tokens', parseInt(v) || 8192)} />
+                        </div>
+                      </div>
+                    )}
+                  </div>
+                ))}
+
+                {showNewModel ? (
+                  <div className="flex gap-2 p-1 bg-muted/30 rounded-xl border border-border shadow-sm">
+                    <input type="text" value={newModelName} onChange={e => setNewModelName(e.target.value)}
+                      placeholder="model key (e.g. deepseek-chat)"
+                      className="flex-1 bg-background border-none rounded-lg px-3 py-2 text-sm text-foreground focus:ring-2 focus:ring-primary/20 transition-all"
+                      onKeyDown={e => e.key === 'Enter' && addModel()} autoFocus />
+                    <button onClick={addModel} className="px-3 py-2 bg-primary text-primary-foreground text-xs font-bold rounded-lg hover:bg-primary/90 shadow-sm">Add</button>
+                    <button onClick={() => { setShowNewModel(false); setNewModelName(''); }}
+                      className="px-3 py-2 text-xs font-bold rounded-lg hover:bg-muted text-muted-foreground">Cancel</button>
+                  </div>
+                ) : (
+                  <button onClick={() => setShowNewModel(true)}
+                    className="flex items-center gap-2 px-4 py-3 text-sm font-semibold text-primary hover:bg-primary/5 rounded-xl border border-dashed border-primary/30 transition-all w-full justify-center">
+                    <Plus size={16} />
+                    Add Model
+                  </button>
+                )}
+              </div>
+            </Section>
+
+          </div>
+        </div>
+      </div>
+    </DashboardLayout>
+  );
+}
+
+/* ===== Helper Components ===== */
+
+function Section({ title, desc, icon, expanded, onToggle, children }: {
+  title: string; desc: string; icon: React.ReactNode; expanded: boolean; onToggle: () => void; children: React.ReactNode;
+}) {
+  return (
+    <div className="bg-card border border-border rounded-2xl overflow-hidden shadow-sm shadow-black/5">
+      <button onClick={onToggle} className="w-full flex items-center gap-4 px-6 py-5 hover:bg-muted/30 transition-all text-left group">
+        <div className={`p-1.5 rounded-lg transition-all ${expanded ? 'bg-primary/10 text-primary' : 'bg-muted text-muted-foreground group-hover:bg-muted-foreground/10'}`}>
+          {expanded ? <ChevronDown size={18} /> : <ChevronRight size={18} />}
+        </div>
+        <div className="flex items-center gap-3 flex-1">
+          <div className="text-muted-foreground">{icon}</div>
+          <div>
+            <span className="text-base font-bold text-foreground tracking-tight">{title}</span>
+            <p className="text-xs text-muted-foreground mt-0.5 font-medium">{desc}</p>
+          </div>
+        </div>
+      </button>
+      {expanded && <div className="px-6 pb-6 pt-2 border-t border-border/40">{children}</div>}
+    </div>
+  );
+}
+
+function FieldInput({ label, value, onChange, type = 'text' }: {
+  label: string; value: string; onChange: (v: string) => void; type?: string;
+}) {
+  return (
+    <div className="space-y-1.5">
+      <label className="text-muted-foreground text-xs font-semibold">{label}</label>
+      <input type={type} value={value} onChange={e => onChange(e.target.value)} step={type === 'number' ? 'any' : undefined}
+        className="w-full bg-background border border-input rounded-xl px-4 py-2.5 text-sm text-foreground focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all shadow-sm" />
+    </div>
+  );
+}

--- a/agentos/app/web/components/layout/DashboardNav.tsx
+++ b/agentos/app/web/components/layout/DashboardNav.tsx
@@ -17,6 +17,7 @@ export function DashboardNav({
     { path: '/gateway', label: 'Gateway' },
     { path: '/tools', label: 'Tools' },
     { path: '/skills', label: 'Skills' },
+    { path: '/settings', label: 'Settings' },
     { path: '/chat', label: 'Chat' },
   ];
 


### PR DESCRIPTION
## Summary
- 新增 `/settings` 页面，支持管理 LLM providers（api_key/base_url/timeout）和 models（provider/model_id/max_output_tokens），并配置 default_model
- 优化 Agent Configuration 的 LLM Backend 板块：移除 Provider 和 Max Tokens 字段，Model 改为下拉菜单选择可用模型
- 导航栏新增 Settings 入口

## Test plan
- [ ] 访问 `/settings` 页面，验证 providers 和 models 列表正确加载
- [ ] 修改 provider api_key / base_url，保存后刷新验证持久化
- [ ] 新增/删除 provider 和 model，验证 CRUD 操作
- [ ] 访问 Agent 详情页 Config tab，验证 Model 下拉菜单列出所有可用模型
- [ ] 选择不同 model 并保存，验证 agent 配置更新

🤖 Generated with [Claude Code](https://claude.com/claude-code)