### PR TITLE
chore: 移除 .agentos/token 的 git 跟踪

### DIFF
--- a/.agentos/token
+++ b/.agentos/token
@@ -1,1 +1,0 @@
-D-uW0-r-syQubnLqbufCRXW4fhdmk6GuH085kp2Mp8c


### PR DESCRIPTION
## Summary
- 移除本地运行时认证 token 文件的 git 跟踪（.gitignore 已有规则）

## Test plan
- [x] `git status` 确认文件已取消跟踪
- [x] `.gitignore` 已包含 `.agentos/token` 规则

🤖 Generated with [Claude Code](https://claude.com/claude-code)