### PR TITLE
fix: keep installed cli aligned with repo

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -489,3 +489,14 @@ python的运行先conda activate base, 再uv run python xxx.py
 失败/风险经验：
 - 当前环境浏览器级 Playwright 仍缺系统库 `libnspr4.so`，即使越权能拉起 web server，也会在 Chromium 启动阶段失败；这类前端 e2e 结果不能作为功能缺陷依据，只能记录为环境阻塞。
 - `npx tsc --noEmit` 与 `next build` 仍会先被仓库既有问题 `components/ThemeProvider.tsx` 的 `next-themes/dist/types` 导入挡住；验证时必须区分”本次新增错误已清零”和”仓库老错误仍在”。
+
+### 2026-03-19 安装脚本与发布流补充
+
+成功经验：
+- `uv tool install --from .` 会把包复制进独立 tool 环境；当安装目录仓库更新或本地 hotfix 未重新注册命令时，`agentos` 可能继续跑旧版代码。改为 `uv tool install --editable --from . --force agentos` 后，CLI 会直接跟随安装目录源码。
+- 安装脚本支持 `AGENTOS_REPO_REF`（兼容旧 `AGENTOS_REPO_BRANCH`）后，发布验证、tag 回滚和灰度安装都更直接，不必修改脚本正文。
+- 给安装脚本补“文本契约测试”很划算：直接断言 shell / PowerShell 脚本里存在 `--editable` 与 `REPO_REF` 覆盖逻辑，能防止回归。
+
+失败/风险经验：
+- 仅修运行时代码里的 `WEB_DIR` 解析不够；如果全局 `agentos` 仍是非 editable 安装，用户依然可能继续执行到旧 CLI。
+- 安装脚本默认仍拉取 `dev`；若某个修复只在特性分支、未合并到 `dev` 或未打 tag，外部一键安装仍拿不到修复，发布时必须同步合并或显式指定 `AGENTOS_REPO_REF`。

--- a/README.md
+++ b/README.md
@@ -81,6 +81,9 @@ irm https://raw.githubusercontent.com/SenseTime-FVG/agentos/dev/install/install.
 安装完成后，运行 `agentos run` 启动服务，然后打开 http://localhost:3000 进行 LLM 等配置。
 
 > 详细说明见 [install/README.md](install/README.md)
+>
+> 如需验证某个发布分支或 tag，可在安装前指定 `AGENTOS_REPO_REF`，例如:
+> `curl -fsSL https://raw.githubusercontent.com/SenseTime-FVG/agentos/dev/install/install.sh | AGENTOS_REPO_REF=v0.5.0 bash`
 
 ### Option B: 手动安装
 

--- a/agentos/app/main.py
+++ b/agentos/app/main.py
@@ -18,7 +18,17 @@ import time
 from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
-WEB_DIR = Path(__file__).resolve().parent / "web"
+
+# 前端目录：优先使用 AGENTOS_HOME/app 下的前端（install.sh 安装场景），
+# 回退到相对 __file__ 的路径（开发环境场景）
+def _resolve_web_dir() -> Path:
+    agentos_home = os.environ.get("AGENTOS_HOME", str(Path.home() / ".agentos"))
+    installed_web = Path(agentos_home) / "app" / "agentos" / "app" / "web"
+    if (installed_web / "node_modules").exists():
+        return installed_web
+    return Path(__file__).resolve().parent / "web"
+
+WEB_DIR = _resolve_web_dir()
 
 
 def _find_npm() -> str:

--- a/install/README.md
+++ b/install/README.md
@@ -16,6 +16,23 @@ irm https://raw.githubusercontent.com/SenseTime-FVG/agentos/dev/install/install.
 
 > 如果 PowerShell 提示执行策略限制，先运行: `Set-ExecutionPolicy RemoteSigned -Scope CurrentUser`
 
+### 指定安装版本
+
+安装脚本默认拉取 `dev` 分支，也支持通过环境变量显式指定分支或 tag，便于发布验证与回滚。
+
+Linux / macOS:
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/SenseTime-FVG/agentos/dev/install/install.sh | AGENTOS_REPO_REF=v0.5.0 bash
+```
+
+Windows（PowerShell）:
+
+```powershell
+$env:AGENTOS_REPO_REF="v0.5.0"
+irm https://raw.githubusercontent.com/SenseTime-FVG/agentos/dev/install/install.ps1 | iex
+```
+
 ## 安装脚本做了什么
 
 脚本会自动完成以下步骤：
@@ -30,7 +47,7 @@ irm https://raw.githubusercontent.com/SenseTime-FVG/agentos/dev/install/install.
 | 6. 安装依赖 | `npm install` 自动安装 Node.js 和 Python 依赖 |
 | 7. 初始化目录 | 创建 AGENTOS_HOME 目录结构，复制预置 agents 和 skills |
 | 8. 初始化配置 | 从 `config_example.yml` 生成 `config.yml`（已有则跳过） |
-| 9. 注册命令 | 注册全局 `agentos` 命令 |
+| 9. 注册命令 | 以 editable 模式注册全局 `agentos` 命令，避免 CLI 与安装目录代码漂移 |
 
 ## 安装完成后
 

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -13,8 +13,8 @@ $ErrorActionPreference = "Stop"
 
 $AGENTOS_HOME = if ($env:AGENTOS_HOME) { $env:AGENTOS_HOME } else { "$env:USERPROFILE\.agentos" }
 $APP_DIR = "$AGENTOS_HOME\app"
-$REPO_URL = "https://github.com/SenseTime-FVG/agentos.git"
-$REPO_BRANCH = "dev"
+$REPO_URL = if ($env:AGENTOS_REPO_URL) { $env:AGENTOS_REPO_URL } else { "https://github.com/SenseTime-FVG/agentos.git" }
+$REPO_REF = if ($env:AGENTOS_REPO_REF) { $env:AGENTOS_REPO_REF } elseif ($env:AGENTOS_REPO_BRANCH) { $env:AGENTOS_REPO_BRANCH } else { "dev" }
 $REQUIRED_PYTHON = "3.12"
 $REQUIRED_NODE = 18
 
@@ -197,18 +197,31 @@ function Install-Node {
 
 function Setup-Repo {
     if (Test-Path "$APP_DIR\.git") {
-        Info "更新 AgentOS..."
+        Info "更新 AgentOS ($REPO_REF)..."
         Push-Location $APP_DIR
-        git fetch origin $REPO_BRANCH --quiet 2>$null
-        git checkout $REPO_BRANCH --quiet 2>$null
-        git pull origin $REPO_BRANCH --ff-only --quiet 2>$null
+        try {
+            git fetch origin $REPO_REF --quiet 2>$null
+            $remoteBranchRef = "refs/remotes/origin/$REPO_REF"
+            git show-ref --verify --quiet $remoteBranchRef 2>$null
+            if ($LASTEXITCODE -eq 0) {
+                git checkout $REPO_REF --quiet 2>$null
+                if ($LASTEXITCODE -ne 0) {
+                    git checkout -B $REPO_REF "origin/$REPO_REF" --quiet 2>$null
+                }
+                git pull origin $REPO_REF --ff-only --quiet 2>$null
+            } else {
+                git checkout --detach FETCH_HEAD --quiet 2>$null
+            }
+        } catch {
+            Warn "git 更新 $REPO_REF 失败，跳过更新"
+        }
         Pop-Location
         Log "AgentOS 已更新"
     } else {
-        Info "克隆 AgentOS 仓库..."
+        Info "克隆 AgentOS 仓库 ($REPO_REF)..."
         $parent = Split-Path $APP_DIR -Parent
         New-Item -ItemType Directory -Force -Path $parent | Out-Null
-        git clone --branch $REPO_BRANCH --depth 1 $REPO_URL $APP_DIR
+        git clone --branch $REPO_REF --depth 1 $REPO_URL $APP_DIR
         Log "AgentOS 克隆完成"
     }
 }
@@ -294,7 +307,7 @@ function Register-Command {
     Push-Location $APP_DIR
 
     try {
-        uv tool install --from . --force agentos 2>$null
+        uv tool install --editable --from . --force agentos 2>$null
     } catch {
         Warn "uv tool install 失败，尝试 pip install..."
         try {
@@ -326,6 +339,7 @@ function Print-Success {
     Write-Host ""
     Write-Host "  安装目录: $APP_DIR"
     Write-Host "  数据目录: $AGENTOS_HOME"
+    Write-Host "  安装来源: $REPO_URL@$REPO_REF"
     Write-Host ""
     if ($IS_CN) {
         Write-Host "  已配置国内镜像: npm($CN_NPM_REGISTRY) pip($CN_PIP_INDEX)"

--- a/install/install.sh
+++ b/install/install.sh
@@ -13,8 +13,8 @@ set -euo pipefail
 
 AGENTOS_HOME="${AGENTOS_HOME:-$HOME/.agentos}"
 APP_DIR="$AGENTOS_HOME/app"
-REPO_URL="https://github.com/SenseTime-FVG/agentos.git"
-REPO_BRANCH="dev"
+REPO_URL="${AGENTOS_REPO_URL:-https://github.com/SenseTime-FVG/agentos.git}"
+REPO_REF="${AGENTOS_REPO_REF:-${AGENTOS_REPO_BRANCH:-dev}}"
 REQUIRED_PYTHON="3.12"
 REQUIRED_NODE="18"
 
@@ -272,19 +272,31 @@ install_node() {
 
 setup_repo() {
   if [ -d "$APP_DIR/.git" ]; then
-    info "更新 AgentOS..."
+    info "更新 AgentOS ($REPO_REF)..."
     cd "$APP_DIR"
-    git fetch origin "$REPO_BRANCH" --quiet
-    git checkout "$REPO_BRANCH" --quiet 2>/dev/null || true
-    git pull origin "$REPO_BRANCH" --ff-only --quiet || {
-      warn "git pull 失败，可能有本地修改，跳过更新"
+    git fetch origin "$REPO_REF" --quiet || {
+      warn "git fetch $REPO_REF 失败，跳过更新"
+      cd - >/dev/null
+      return
     }
+    if git show-ref --verify --quiet "refs/remotes/origin/$REPO_REF"; then
+      git checkout "$REPO_REF" --quiet 2>/dev/null || git checkout -B "$REPO_REF" "origin/$REPO_REF" --quiet
+      git pull origin "$REPO_REF" --ff-only --quiet || {
+        warn "git pull 失败，可能有本地修改，跳过更新"
+      }
+    else
+      git checkout --detach FETCH_HEAD --quiet || {
+        warn "git checkout $REPO_REF 失败，跳过更新"
+        cd - >/dev/null
+        return
+      }
+    fi
     cd - >/dev/null
     log "AgentOS 已更新"
   else
-    info "克隆 AgentOS 仓库..."
+    info "克隆 AgentOS 仓库 ($REPO_REF)..."
     mkdir -p "$(dirname "$APP_DIR")"
-    git clone --branch "$REPO_BRANCH" --depth 1 "$REPO_URL" "$APP_DIR"
+    git clone --branch "$REPO_REF" --depth 1 "$REPO_URL" "$APP_DIR"
     log "AgentOS 克隆完成"
   fi
 }
@@ -389,7 +401,8 @@ register_command() {
   info "注册 agentos 命令..."
   cd "$APP_DIR"
 
-  uv tool install --from . --force agentos 2>/dev/null || {
+  # 使用 editable 安装，避免 uv tool 环境里残留一份过期代码副本。
+  uv tool install --editable --from . --force agentos 2>/dev/null || {
     # 降级：用 pip install -e
     warn "uv tool install 失败，尝试 pip install..."
     uv pip install -e . 2>/dev/null || pip install -e . 2>/dev/null || {
@@ -422,6 +435,7 @@ print_success() {
   echo ""
   echo "  安装目录: $APP_DIR"
   echo "  数据目录: $AGENTOS_HOME"
+  echo "  安装来源: $REPO_URL@$REPO_REF"
   echo ""
   if [ "$IS_CN" = "true" ]; then
     echo "  已配置国内镜像: npm($CN_NPM_REGISTRY) pip($CN_UV_INDEX)"

--- a/install/install.sh
+++ b/install/install.sh
@@ -120,6 +120,39 @@ EOF
   export NVM_NODEJS_ORG_MIRROR="$CN_NVM_MIRROR"
 }
 
+# ── 步骤 1b: 安装 git ──
+
+install_git() {
+  if command_exists git; then
+    log "git 已安装: $(git --version)"
+    return
+  fi
+
+  info "安装 git..."
+
+  if command_exists apt-get; then
+    sudo apt-get update -qq && sudo apt-get install -y -qq git
+  elif command_exists yum; then
+    sudo yum install -y -q git
+  elif command_exists dnf; then
+    sudo dnf install -y -q git
+  elif command_exists pacman; then
+    sudo pacman -S --noconfirm git
+  elif command_exists brew; then
+    brew install git
+  elif command_exists apk; then
+    sudo apk add --quiet git
+  else
+    fail "无法自动安装 git，请手动安装后重试: https://git-scm.com/downloads"
+  fi
+
+  if command_exists git; then
+    log "git 安装成功: $(git --version)"
+  else
+    fail "git 安装失败，请手动安装: https://git-scm.com/downloads"
+  fi
+}
+
 # ── 步骤 2: 安装 uv + Python ──
 
 install_uv() {
@@ -265,8 +298,22 @@ install_deps() {
   # 设置 uv 缓存目录（避免权限问题）
   export UV_CACHE_DIR="${UV_CACHE_DIR:-/tmp/uv_cache}"
 
+  # 1) Python 依赖
+  info "安装 Python 依赖..."
+  uv sync 2>&1 | tail -5
+  log "Python 依赖安装完成"
+
+  # 2) 根目录 npm 依赖（跳过 postinstall，避免重复）
+  info "安装根目录 npm 依赖..."
+  npm install --ignore-scripts 2>&1 | tail -5
+  log "根目录 npm 依赖安装完成"
+
+  # 3) 前端依赖
+  info "安装前端依赖..."
+  cd "$APP_DIR/agentos/app/web"
   npm install 2>&1 | tail -5
-  log "项目依赖安装完成"
+  cd "$APP_DIR"
+  log "前端依赖安装完成"
 }
 
 # ── 步骤 5b: 构建 AGENTOS_HOME 目录结构 ──
@@ -412,6 +459,7 @@ main() {
 
   detect_region
   configure_cn_mirrors
+  install_git
   install_uv
   install_python
   install_nvm

--- a/install/install.sh
+++ b/install/install.sh
@@ -364,7 +364,8 @@ setup_home_dir() {
 # ── 步骤 6: 初始化配置文件 ──
 
 setup_config() {
-  local config_file="$APP_DIR/config.yml"
+  # 配置文件放在 AGENTOS_HOME 根目录，与代码 DEFAULT_CONFIG_PATH 一致
+  local config_file="$AGENTOS_HOME/config.yml"
   local example_file="$APP_DIR/config_example.yml"
 
   if [ -f "$config_file" ]; then
@@ -375,10 +376,10 @@ setup_config() {
 
   if [ -f "$example_file" ]; then
     cp "$example_file" "$config_file"
-    log "已从 config_example.yml 生成配置文件"
+    log "已从 config_example.yml 生成配置文件: $config_file"
     info "请编辑 $config_file 填入 LLM API Key 等配置"
   else
-    warn "未找到 config_example.yml，请手动创建 config.yml"
+    warn "未找到 config_example.yml，请手动创建 $config_file"
   fi
 }
 

--- a/tests/unit/test_app_main.py
+++ b/tests/unit/test_app_main.py
@@ -1,0 +1,19 @@
+"""agentos.app.main 的安装路径解析回归测试"""
+
+from pathlib import Path
+
+from agentos.app import main as app_main
+
+
+def test_resolve_web_dir_prefers_installed_agentos_home(monkeypatch, tmp_path):
+    installed_web = tmp_path / "app" / "agentos" / "app" / "web"
+    (installed_web / "node_modules").mkdir(parents=True)
+    monkeypatch.setenv("AGENTOS_HOME", str(tmp_path))
+
+    assert app_main._resolve_web_dir() == installed_web
+
+
+def test_resolve_web_dir_falls_back_to_repo_web_dir(monkeypatch, tmp_path):
+    monkeypatch.setenv("AGENTOS_HOME", str(tmp_path))
+
+    assert app_main._resolve_web_dir() == Path(app_main.__file__).resolve().parent / "web"

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -1,0 +1,20 @@
+"""安装脚本关键行为回归测试"""
+
+from pathlib import Path
+
+
+ROOT = Path(__file__).resolve().parents[2]
+
+
+def test_install_sh_uses_editable_tool_install():
+    content = (ROOT / "install" / "install.sh").read_text(encoding="utf-8")
+
+    assert "uv tool install --editable --from . --force agentos" in content
+    assert 'REPO_REF="${AGENTOS_REPO_REF:-${AGENTOS_REPO_BRANCH:-dev}}"' in content
+
+
+def test_install_ps1_uses_editable_tool_install():
+    content = (ROOT / "install" / "install.ps1").read_text(encoding="utf-8")
+
+    assert "uv tool install --editable --from . --force agentos" in content
+    assert '$REPO_REF = if ($env:AGENTOS_REPO_REF)' in content


### PR DESCRIPTION
## Summary
- install `agentos` via `uv tool install --editable` so the global CLI stays aligned with the installed repo
- support `AGENTOS_REPO_REF` / `AGENTOS_REPO_BRANCH` in install scripts for branch or tag based installs
- add install-script and web-dir resolution regression tests

## Testing
- `bash -n install/install.sh`
- `.venv/bin/python -m pytest tests/unit/test_app_main.py tests/unit/test_install_scripts.py -q`
