### PR TITLE
feat: 支持 --dev 开发模式安装和运行

### DIFF
--- a/agentos/app/main.py
+++ b/agentos/app/main.py
@@ -2,7 +2,7 @@
 """AgentOS 统一 CLI 入口
 
 用法:
-    agentos run [--port 8000] [--frontend-port 3000] [--no-frontend]
+    agentos run [--port 8000] [--frontend-port 3000] [--no-frontend] [--dev]
     agentos cli [--host localhost] [--port 8000] [--agent default] [--session ID] [--debug] [-e MSG]
     agentos version
 """
@@ -19,16 +19,17 @@ from pathlib import Path
 
 PROJECT_ROOT = Path(__file__).resolve().parents[2]
 
-# 前端目录：优先使用 AGENTOS_HOME/app 下的前端（install.sh 安装场景），
-# 回退到相对 __file__ 的路径（开发环境场景）
-def _resolve_web_dir() -> Path:
+# 前端目录解析：根据 project_root 定位
+def _resolve_web_dir(project_root: Path) -> Path:
+    web_dir = project_root / "agentos" / "app" / "web"
+    if (web_dir / "node_modules").exists():
+        return web_dir
+    # 回退到 AGENTOS_HOME/app 下的前端（install.sh 安装场景）
     agentos_home = os.environ.get("AGENTOS_HOME", str(Path.home() / ".agentos"))
     installed_web = Path(agentos_home) / "app" / "agentos" / "app" / "web"
     if (installed_web / "node_modules").exists():
         return installed_web
-    return Path(__file__).resolve().parent / "web"
-
-WEB_DIR = _resolve_web_dir()
+    return web_dir
 
 
 def _find_npm() -> str:
@@ -59,6 +60,20 @@ def cmd_run(args: argparse.Namespace) -> int:
     backend_port = args.port
     frontend_port = args.frontend_port
     no_frontend = args.no_frontend
+    dev_mode = args.dev
+
+    # --dev 模式：使用当前工作目录的代码
+    if dev_mode:
+        project_root = Path.cwd().resolve()
+        # 校验当前目录是否是 agentos 项目
+        if not (project_root / "agentos" / "app" / "gateway" / "main.py").exists():
+            print("错误: 当前目录不是 AgentOS 项目根目录", file=sys.stderr)
+            return 1
+        print(f"[dev] 使用本地代码: {project_root}")
+    else:
+        project_root = PROJECT_ROOT
+
+    web_dir = _resolve_web_dir(project_root)
 
     # 端口检查
     if not _check_port(backend_port):
@@ -86,6 +101,12 @@ def cmd_run(args: argparse.Namespace) -> int:
     signal.signal(signal.SIGINT, cleanup)
     signal.signal(signal.SIGTERM, cleanup)
 
+    # 构建子进程环境变量
+    env = os.environ.copy()
+    if dev_mode:
+        # 将本地项目根目录置于 PYTHONPATH 最前，确保子进程优先导入本地代码
+        env["PYTHONPATH"] = str(project_root) + os.pathsep + env.get("PYTHONPATH", "")
+
     # 启动后端
     backend_cmd = [
         sys.executable, "-m", "uvicorn",
@@ -95,7 +116,7 @@ def cmd_run(args: argparse.Namespace) -> int:
         "--port", str(backend_port),
     ]
     print(f"启动后端服务: http://localhost:{backend_port}")
-    backend_proc = subprocess.Popen(backend_cmd, cwd=str(PROJECT_ROOT))
+    backend_proc = subprocess.Popen(backend_cmd, cwd=str(project_root), env=env)
     procs.append(backend_proc)
 
     # 等待后端启动
@@ -110,16 +131,16 @@ def cmd_run(args: argparse.Namespace) -> int:
         npm = _find_npm()
         if not npm:
             print("警告: 未找到 npm，跳过前端启动。安装 Node.js 后可使用前端 dashboard。", file=sys.stderr)
-        elif not (WEB_DIR / "node_modules").exists():
+        elif not (web_dir / "node_modules").exists():
             print("警告: 前端依赖未安装，请先执行 'npm install'。跳过前端启动。", file=sys.stderr)
         else:
             print(f"启动前端 dashboard: http://localhost:{frontend_port}")
-            env = os.environ.copy()
-            env["PORT"] = str(frontend_port)
+            frontend_env = env.copy()
+            frontend_env["PORT"] = str(frontend_port)
             frontend_proc = subprocess.Popen(
                 [npm, "run", "dev"],
-                cwd=str(WEB_DIR),
-                env=env,
+                cwd=str(web_dir),
+                env=frontend_env,
             )
             procs.append(frontend_proc)
 
@@ -142,8 +163,10 @@ def cmd_run(args: argparse.Namespace) -> int:
     # 后端会在启动时打印 token URL，这里也提示用户
     print()
     print("=" * 50)
-    print(f"  AgentOS 已启动")
+    print(f"  AgentOS 已启动" + (" (dev mode)" if dev_mode else ""))
     print(f"  后端 API:    http://localhost:{backend_port}")
+    if dev_mode:
+        print(f"  代码目录:    {project_root}")
     if frontend_proc:
         print(f"  Dashboard:   http://localhost:{frontend_port}")
     print(f"  CLI 连接:    agentos cli --port {backend_port}")
@@ -215,6 +238,7 @@ def main() -> int:
     run_parser.add_argument("--port", type=int, default=8000, help="后端端口 (默认 8000)")
     run_parser.add_argument("--frontend-port", type=int, default=3000, help="前端端口 (默认 3000)")
     run_parser.add_argument("--no-frontend", action="store_true", help="仅启动后端，不启动前端")
+    run_parser.add_argument("--dev", action="store_true", help="开发模式：使用当前目录的代码而非安装目录")
 
     # agentos cli
     cli_parser = subparsers.add_parser("cli", help="启动 CLI 交互客户端")

--- a/agentos/app/web/app/setup/page.tsx
+++ b/agentos/app/web/app/setup/page.tsx
@@ -49,8 +49,8 @@ export default function SetupPage() {
   useEffect(() => {
     const fetchPresets = async () => {
       try {
-        const data = await authGet<CategoryPreset[]>(`${API_BASE}/api/config/llm-presets`);
-        setPresets(data);
+        const data = await authGet<{ categories: CategoryPreset[] }>(`${API_BASE}/api/config/llm-presets`);
+        setPresets(Array.isArray(data) ? data : data.categories ?? []);
       } catch (e) {
         console.error('加载 LLM 预设失败:', e);
         // 使用内置默认值，避免因接口不存在导致页面无法使用

--- a/install/install.sh
+++ b/install/install.sh
@@ -7,6 +7,9 @@
 # 或本地执行:
 #   bash install/install.sh
 #
+# 开发模式（跳过克隆，使用当前目录代码）:
+#   bash install/install.sh --dev
+#
 set -euo pipefail
 
 # ── 配置 ──
@@ -17,6 +20,7 @@ REPO_URL="${AGENTOS_REPO_URL:-https://github.com/SenseTime-FVG/agentos.git}"
 REPO_REF="${AGENTOS_REPO_REF:-${AGENTOS_REPO_BRANCH:-dev}}"
 REQUIRED_PYTHON="3.12"
 REQUIRED_NODE="18"
+DEV_MODE=false
 
 # 国内镜像
 CN_NPM_REGISTRY="https://registry.npmmirror.com"
@@ -433,9 +437,14 @@ print_success() {
   echo -e "${GREEN}  AgentOS 安装完成!${NC}"
   echo -e "${GREEN}════════════════════════════════════════════════════${NC}"
   echo ""
-  echo "  安装目录: $APP_DIR"
+  if [ "$DEV_MODE" = "true" ]; then
+    echo "  模式:     开发模式"
+    echo "  代码目录: $APP_DIR"
+  else
+    echo "  安装目录: $APP_DIR"
+    echo "  安装来源: $REPO_URL@$REPO_REF"
+  fi
   echo "  数据目录: $AGENTOS_HOME"
-  echo "  安装来源: $REPO_URL@$REPO_REF"
   echo ""
   if [ "$IS_CN" = "true" ]; then
     echo "  已配置国内镜像: npm($CN_NPM_REGISTRY) pip($CN_UV_INDEX)"
@@ -459,32 +468,68 @@ print_success() {
 # ── 主流程 ──
 
 main() {
+  # 解析参数
+  for arg in "$@"; do
+    case "$arg" in
+      --dev) DEV_MODE=true ;;
+    esac
+  done
+
   echo ""
   echo -e "${BLUE}╔══════════════════════════════════════════════╗${NC}"
   echo -e "${BLUE}║         AgentOS 一键安装脚本                ║${NC}"
   echo -e "${BLUE}╚══════════════════════════════════════════════╝${NC}"
   echo ""
 
-  # 选择安装路径
-  local default_dir="$AGENTOS_HOME"
-  AGENTOS_HOME=$(prompt_input "安装路径" "$default_dir")
-  APP_DIR="$AGENTOS_HOME/app"
-  log "安装到: $AGENTOS_HOME"
-  echo ""
+  if [ "$DEV_MODE" = "true" ]; then
+    # 开发模式：使用当前目录的代码，跳过克隆
+    # 找到 install.sh 所在的仓库根目录
+    local script_dir
+    script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+    APP_DIR="$(cd "$script_dir/.." && pwd)"
 
-  detect_region
-  configure_cn_mirrors
-  install_git
-  install_uv
-  install_python
-  install_nvm
-  install_node
-  setup_repo
-  install_deps
-  setup_home_dir
-  setup_config
-  register_command
-  print_success
+    # 校验是否是 agentos 项目
+    if [ ! -f "$APP_DIR/agentos/app/gateway/main.py" ]; then
+      fail "当前仓库不是 AgentOS 项目，无法使用 --dev 模式"
+    fi
+
+    log "开发模式: 使用本地代码 $APP_DIR"
+    echo ""
+
+    detect_region
+    configure_cn_mirrors
+    install_uv
+    install_python
+    install_nvm
+    install_node
+    # 跳过 setup_repo（不克隆）
+    install_deps
+    setup_home_dir
+    setup_config
+    register_command
+    print_success
+  else
+    # 正常安装模式
+    local default_dir="$AGENTOS_HOME"
+    AGENTOS_HOME=$(prompt_input "安装路径" "$default_dir")
+    APP_DIR="$AGENTOS_HOME/app"
+    log "安装到: $AGENTOS_HOME"
+    echo ""
+
+    detect_region
+    configure_cn_mirrors
+    install_git
+    install_uv
+    install_python
+    install_nvm
+    install_node
+    setup_repo
+    install_deps
+    setup_home_dir
+    setup_config
+    register_command
+    print_success
+  fi
 }
 
 main "$@"


### PR DESCRIPTION
## Summary
- `install.sh --dev`: 跳过 git clone，用当前仓库目录 editable 安装，本地代码修改立即生效
- `agentos run --dev`: 备用方案，通过 PYTHONPATH 优先导入当前工作目录的代码
- 前端目录解析重构为根据 project_root 定位，dev/安装环境自动适配

## Test plan
- [ ] `bash install/install.sh --dev` 安装后 `agentos run` 使用本地代码
- [ ] 修改本地代码后无需重新安装，重启即生效
- [ ] `bash install/install.sh`（无 --dev）正常安装到 ~/.agentos/app
- [ ] `agentos run --dev` 在非项目目录下报错提示

🤖 Generated with [Claude Code](https://claude.com/claude-code)