### PR TITLE
feat: LLM extra_body 透传支持

### DIFF
--- a/agentos/adapters/llm/base.py
+++ b/agentos/adapters/llm/base.py
@@ -11,5 +11,6 @@ class LLMProvider:
         tools: list[dict[str, Any]] | None = None,
         temperature: float = 0.2,
         max_tokens: int | None = None,
+        extra_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         raise NotImplementedError

--- a/agentos/adapters/llm/providers/anthropic_provider.py
+++ b/agentos/adapters/llm/providers/anthropic_provider.py
@@ -47,11 +47,7 @@ class AnthropicProvider(LLMProvider):
         if tools:
             req["tools"] = [self._convert_tool(t) for t in tools]
 
-        # 合并 extra_body 到请求参数（Anthropic SDK 直接接受关键字参数）
-        if extra_body:
-            req.update(extra_body)
-
-        response = await self.client.messages.create(**req)
+        response = await self.client.messages.create(**req, extra_body=extra_body)
 
         content_text = ""
         tool_calls: list[dict[str, Any]] = []

--- a/agentos/adapters/llm/providers/anthropic_provider.py
+++ b/agentos/adapters/llm/providers/anthropic_provider.py
@@ -25,6 +25,7 @@ class AnthropicProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         temperature: float = 0.2,
         max_tokens: int | None = None,
+        extra_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         system_messages = [m for m in messages if m.get("role") == "system"]
         non_system_messages = [m for m in messages if m.get("role") != "system"]
@@ -45,6 +46,10 @@ class AnthropicProvider(LLMProvider):
 
         if tools:
             req["tools"] = [self._convert_tool(t) for t in tools]
+
+        # 合并 extra_body 到请求参数（Anthropic SDK 直接接受关键字参数）
+        if extra_body:
+            req.update(extra_body)
 
         response = await self.client.messages.create(**req)
 

--- a/agentos/adapters/llm/providers/gemini_provider.py
+++ b/agentos/adapters/llm/providers/gemini_provider.py
@@ -53,6 +53,7 @@ class GeminiProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         temperature: float = 0.2,
         max_tokens: int | None = None,
+        extra_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         normalized_messages = self._clean_messages(messages)
 
@@ -65,6 +66,8 @@ class GeminiProvider(LLMProvider):
             req["tools"] = [{"type": "function", "function": t} for t in tools]
         if max_tokens:
             req["max_tokens"] = max_tokens
+        if extra_body:
+            req["extra_body"] = extra_body
 
         response = await self.client.chat.completions.create(**req)
         choice = response.choices[0]

--- a/agentos/adapters/llm/providers/mock_provider.py
+++ b/agentos/adapters/llm/providers/mock_provider.py
@@ -13,8 +13,9 @@ class MockProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         temperature: float = 0.2,
         max_tokens: int | None = None,
+        extra_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
-        _ = (model, temperature, max_tokens)
+        _ = (model, temperature, max_tokens, extra_body)
         last = messages[-1] if messages else {"content": ""}
         content = str(last.get("content", ""))
 

--- a/agentos/adapters/llm/providers/openai_provider.py
+++ b/agentos/adapters/llm/providers/openai_provider.py
@@ -25,6 +25,7 @@ class OpenAIProvider(LLMProvider):
         tools: list[dict[str, Any]] | None = None,
         temperature: float = 0.2,
         max_tokens: int | None = None,
+        extra_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         normalized_messages = self._normalize_messages(messages)
         req: dict[str, Any] = {
@@ -36,6 +37,8 @@ class OpenAIProvider(LLMProvider):
             req["tools"] = [{"type": "function", "function": t} for t in tools]
         if max_tokens:
             req["max_tokens"] = max_tokens
+        if extra_body:
+            req["extra_body"] = extra_body
 
         response = await self.client.chat.completions.create(**req)
         choice = response.choices[0]

--- a/agentos/capabilities/agents/config.py
+++ b/agentos/capabilities/agents/config.py
@@ -23,6 +23,7 @@ class AgentConfig:
     model: str = "gpt-4o-mini"                        # 模型名称
     temperature: float = 0.2                          # 温度参数
     max_tokens: int | None = None                     # 最大 token 数
+    extra_body: dict = field(default_factory=dict)    # 透传给 LLM API 的额外参数
 
     # 行为配置
     system_prompt: str = ""                           # 系统提示词
@@ -50,6 +51,7 @@ class AgentConfig:
             "model": self.model,
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
+            "extra_body": dict(self.extra_body),
             "system_prompt": self.system_prompt,
             "tools": list(self.tools),
             "skills": list(self.skills),
@@ -73,6 +75,7 @@ class AgentConfig:
             model=data.get("model", "gpt-4o-mini"),
             temperature=data.get("temperature", 0.2),
             max_tokens=data.get("max_tokens"),
+            extra_body=dict(data.get("extra_body", {})),
             system_prompt=data.get("system_prompt", ""),
             tools=list(data.get("tools", [])),
             skills=list(data.get("skills", [])),

--- a/agentos/capabilities/agents/config.py
+++ b/agentos/capabilities/agents/config.py
@@ -23,7 +23,7 @@ class AgentConfig:
     model: str = "gpt-4o-mini"                        # 模型名称
     temperature: float = 0.2                          # 温度参数
     max_tokens: int | None = None                     # 最大 token 数
-    extra_body: dict = field(default_factory=dict)    # 透传给 LLM API 的额外参数
+    extra_body: dict[str, Any] = field(default_factory=dict)  # 透传给 LLM API 的额外参数
 
     # 行为配置
     system_prompt: str = ""                           # 系统提示词

--- a/agentos/kernel/runtime/workers/agent_worker.py
+++ b/agentos/kernel/runtime/workers/agent_worker.py
@@ -85,6 +85,14 @@ class AgentSessionWorker(SessionWorker):
             return self.agent_config.temperature
         return config.get("agent.temperature", 0.2)
 
+    def _get_extra_body(self) -> dict:
+        """获取 extra_body：agent 级别覆盖 model 级别"""
+        model_key = self._get_model_key()
+        model_extra = config.get_model_extra_body(model_key)
+        if self.agent_config and self.agent_config.extra_body:
+            model_extra.update(self.agent_config.extra_body)
+        return model_extra
+
     def _get_filtered_tools(self) -> list[dict]:
         """根据 Agent 配置过滤可用工具"""
         all_tools = self.rt.tool_registry.as_llm_tools()
@@ -281,6 +289,7 @@ class AgentSessionWorker(SessionWorker):
                     "messages": messages,
                     "tools": self._get_filtered_tools(),
                     "temperature": self._get_temperature(),
+                    "extra_body": self._get_extra_body(),
                 },
             )
         )
@@ -459,6 +468,7 @@ class AgentSessionWorker(SessionWorker):
                     "messages": state.messages,
                     "tools": self._get_filtered_tools(),
                     "temperature": self._get_temperature(),
+                    "extra_body": self._get_extra_body(),
                 },
             )
         )

--- a/agentos/kernel/runtime/workers/llm_worker.py
+++ b/agentos/kernel/runtime/workers/llm_worker.py
@@ -48,11 +48,11 @@ class LLMSessionWorker(SessionWorker):
         tools = event.payload.get("tools")
         temperature = float(event.payload.get("temperature", config.get("agent.temperature", 0.2)))
         max_tokens = event.payload.get("max_tokens")
-        extra_body = event.payload.get("extra_body") or {}
+        extra_body = event.payload.get("extra_body") or None
 
         logger.debug(
-            "LLM call input | provider=%s model=%s llm_call_id=%s messages=%s tools=%s",
-            provider_name, model, llm_call_id, messages, tools,
+            "LLM call input | provider=%s model=%s llm_call_id=%s extra_body=%s messages=%s tools=%s",
+            provider_name, model, llm_call_id, extra_body, messages, tools,
         )
 
         await self.bus.publish(
@@ -74,7 +74,7 @@ class LLMSessionWorker(SessionWorker):
                 tools=tools,
                 temperature=temperature,
                 max_tokens=max_tokens,
-                extra_body=extra_body if extra_body else None,
+                extra_body=extra_body,
             )
             await self.bus.publish(
                 EventEnvelope(

--- a/agentos/kernel/runtime/workers/llm_worker.py
+++ b/agentos/kernel/runtime/workers/llm_worker.py
@@ -48,6 +48,7 @@ class LLMSessionWorker(SessionWorker):
         tools = event.payload.get("tools")
         temperature = float(event.payload.get("temperature", config.get("agent.temperature", 0.2)))
         max_tokens = event.payload.get("max_tokens")
+        extra_body = event.payload.get("extra_body") or {}
 
         logger.debug(
             "LLM call input | provider=%s model=%s llm_call_id=%s messages=%s tools=%s",
@@ -73,6 +74,7 @@ class LLMSessionWorker(SessionWorker):
                 tools=tools,
                 temperature=temperature,
                 max_tokens=max_tokens,
+                extra_body=extra_body if extra_body else None,
             )
             await self.bus.publish(
                 EventEnvelope(

--- a/agentos/platform/config/config.py
+++ b/agentos/platform/config/config.py
@@ -502,6 +502,25 @@ class Config:
         logger.warning("未知的模型 key: %s，使用 mock provider", model_key)
         return "mock", model_key
 
+    def get_model_extra_body(self, model_key: str | None = None) -> dict:
+        """获取模型配置中的 extra_body（透传给 LLM API 请求体的额外参数）。
+
+        Args:
+            model_key: llm.models 中的 key，为 None 时使用 llm.default_model。
+        Returns:
+            extra_body dict，无配置时返回空 dict
+        """
+        if not model_key:
+            model_key = self.get("llm.default_model", "mock")
+        models = self.get("llm.models", {})
+        if model_key in models:
+            return dict(models[model_key].get("extra_body", {}))
+        # 向后兼容：反查 model_id
+        for _key, entry in models.items():
+            if isinstance(entry, dict) and entry.get("model_id") == model_key:
+                return dict(entry.get("extra_body", {}))
+        return {}
+
 
 config = Config()
 logger.info("Config loaded: %s", config)

--- a/tests/unit/test_agent_config.py
+++ b/tests/unit/test_agent_config.py
@@ -37,7 +37,7 @@ class TestAgentConfig:
         d = a.to_dict()
         expected_keys = {
             "id", "name", "description", "provider", "model",
-            "temperature", "max_tokens", "system_prompt", "tools",
+            "temperature", "max_tokens", "extra_body", "system_prompt", "tools",
             "skills", "workdir", "can_delegate_to", "max_delegation_depth",
             "max_pingpong_turns",
             "enabled", "created_at", "updated_at",

--- a/tests/unit/test_agent_config.py
+++ b/tests/unit/test_agent_config.py
@@ -69,6 +69,23 @@ class TestAgentConfig:
         assert a.max_send_depth == 4
         assert a.max_pingpong_turns == 7
 
+    def test_extra_body_default_empty(self):
+        a = AgentConfig(id="x", name="X")
+        assert a.extra_body == {}
+
+    def test_extra_body_roundtrip(self):
+        eb = {"thinking": {"type": "adaptive"}, "reasoning_effort": "high"}
+        a = AgentConfig.create(id="x", name="X", extra_body=eb)
+        d = a.to_dict()
+        assert d["extra_body"] == eb
+        b = AgentConfig.from_dict(d)
+        assert b.extra_body == eb
+
+    def test_extra_body_from_dict_missing(self):
+        """extra_body 未配置时默认为空 dict"""
+        a = AgentConfig.from_dict({"id": "x"})
+        assert a.extra_body == {}
+
     def test_workdir_default_empty(self):
         a = AgentConfig(id="x", name="X")
         assert a.workdir == ""

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -51,3 +51,44 @@ class TestConfig:
         cfg = Config(config_path=tmp_path / "nonexist.yml")
         cfg.set("agent.model", "claude-opus")
         assert cfg.get("agent.model") == "claude-opus"
+
+    def test_get_model_extra_body(self, tmp_path):
+        yml = tmp_path / "config.yml"
+        yml.write_text(
+            "llm:\n"
+            "  models:\n"
+            "    o3:\n"
+            "      provider: openai\n"
+            "      model_id: o3\n"
+            "      extra_body:\n"
+            "        reasoning_effort: high\n"
+            "    gpt-4o:\n"
+            "      provider: openai\n"
+            "      model_id: gpt-4o\n",
+            encoding="utf-8",
+        )
+        cfg = Config(config_path=yml)
+        # 有 extra_body 的模型
+        assert cfg.get_model_extra_body("o3") == {"reasoning_effort": "high"}
+        # 无 extra_body 的模型
+        assert cfg.get_model_extra_body("gpt-4o") == {}
+        # 不存在的模型
+        assert cfg.get_model_extra_body("nonexist") == {}
+
+    def test_get_model_extra_body_nested(self, tmp_path):
+        yml = tmp_path / "config.yml"
+        yml.write_text(
+            "llm:\n"
+            "  models:\n"
+            "    claude-thinking:\n"
+            "      provider: anthropic\n"
+            "      model_id: claude-opus-4-6\n"
+            "      extra_body:\n"
+            "        thinking:\n"
+            "          type: adaptive\n",
+            encoding="utf-8",
+        )
+        cfg = Config(config_path=yml)
+        assert cfg.get_model_extra_body("claude-thinking") == {
+            "thinking": {"type": "adaptive"}
+        }


### PR DESCRIPTION
## Summary

- 在 `llm.models` 配置中新增 `extra_body` 字段，原样透传到各 LLM provider 的 API 请求体
- 用户可按各 provider 原生文档配置 `reasoning_effort`、`thinking` 等参数，无需代码层适配
- 支持 model 级别和 agent 级别两层配置，agent 级别可覆盖 model 级别

**配置示例：**
```yaml
llm:
  models:
    o3:
      provider: openai
      model_id: o3
      extra_body:
        reasoning_effort: high
    claude-opus-thinking:
      provider: anthropic
      model_id: claude-opus-4-6
      extra_body:
        thinking:
          type: adaptive
    qwen-thinking:
      provider: openai
      model_id: qwen3-235b-a22b
      extra_body:
        enable_thinking: true
        thinking_budget: 50
```

**改动文件（11 个）：**
- `config.py` — 新增 `get_model_extra_body()` 方法
- `base.py` + 4 个 provider — `call()` 签名加 `extra_body` 参数
- `AgentConfig` — 新增 `extra_body` 字段 + 序列化
- `agent_worker.py` — 新增 `_get_extra_body()`，事件 payload 透传
- `llm_worker.py` — 提取 extra_body 并传给 provider，debug 日志补充
- 2 个测试文件 — 补充 extra_body 相关单元测试

## Test plan

- [x] 单元测试全部通过（新增 5 个 extra_body 测试）
- [ ] 配置 extra_body 后真实 LLM 调用验证
- [ ] 空 extra_body / 无 extra_body 的向后兼容验证

🤖 Generated with [Claude Code](https://claude.com/claude-code)