### PR TITLE
fix: 替换外部 shadcn 头像为本地 icon.png

### DIFF
--- a/agentos/app/web/components/layout/DashboardLayout.tsx
+++ b/agentos/app/web/components/layout/DashboardLayout.tsx
@@ -113,7 +113,7 @@ export function DashboardLayout({ children }: DashboardLayoutProps) {
             </div>
             <GlobalReminderBell />
             <Avatar className="h-8 w-8 cursor-pointer">
-              <AvatarImage src="https://github.com/shadcn.png" alt="@shadcn" />
+              <AvatarImage src="/icon.png" alt="AgentOS" />
               <AvatarFallback>AO</AvatarFallback>
             </Avatar>
           </div>


### PR DESCRIPTION
## Summary
- 将 DashboardLayout 中的外部头像图片 `https://github.com/shadcn.png` 替换为本地 `/icon.png`

🤖 Generated with [Claude Code](https://claude.com/claude-code)