### PR TITLE
fix: send_message 创建的 session 不在对话列表实时显示

### DIFF
--- a/agentos/adapters/channels/websocket_channel.py
+++ b/agentos/adapters/channels/websocket_channel.py
@@ -18,6 +18,7 @@ from agentos.kernel.events.types import (
     LLM_CALL_REQUESTED,
     NOTIFICATION_PUSH,
     NOTIFICATION_SESSION,
+    SESSION_CREATED,
     TOOL_CALL_REQUESTED,
     TOOL_CALL_RESULT,
     TOOL_CONFIRMATION_REQUESTED,
@@ -304,6 +305,7 @@ class WebSocketChannel(Channel):
 
         # 部分事件为连接级广播（不依赖 session 绑定）
         if event.type in {
+            SESSION_CREATED,
             TOOL_CONFIRMATION_REQUESTED,
             USER_QUESTION_ASKED,
             USER_QUESTION_ANSWERED,
@@ -325,6 +327,16 @@ class WebSocketChannel(Channel):
 
     def _map(self, event: EventEnvelope) -> dict[str, Any] | None:
         """将事件映射为前端消息格式"""
+        if event.type == SESSION_CREATED:
+            return {
+                "type": "session_list_changed",
+                "session_id": event.session_id,
+                "payload": {
+                    "agent_id": event.payload.get("agent_id"),
+                    "reason": "send_message",
+                },
+                "timestamp": event.ts,
+            }
         if event.type == AGENT_STEP_STARTED:
             return {
                 "type": "agent_thinking",

--- a/agentos/app/web/app/chat/page.tsx
+++ b/agentos/app/web/app/chat/page.tsx
@@ -361,6 +361,14 @@ function ChatContent() {
     }
   }, [agents, selectedAgentId]);
 
+  // 切换 agent 时刷新 session 列表
+  useEffect(() => {
+    if (selectedAgentId) {
+      refreshTaskGroups();
+    }
+  // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [selectedAgentId]);
+
   const selectedSessions = selectedAgentId
     ? (sessionsByAgent[selectedAgentId] || []).sort((a, b) => b.last_active - a.last_active)
     : [];

--- a/agentos/app/web/contexts/ChatSessionContext.tsx
+++ b/agentos/app/web/contexts/ChatSessionContext.tsx
@@ -328,6 +328,11 @@ export function ChatSessionProvider({ children }: { children: React.ReactNode })
         }));
         break;
       }
+      case 'session_list_changed': {
+        // 后端通知有新 session（如 send_message 创建），刷新列表
+        loadSessionList();
+        break;
+      }
       case 'session_deleted': {
         const deletedSid = String(payload.session_id || '');
         if (deletedSid) {

--- a/agentos/kernel/events/types.py
+++ b/agentos/kernel/events/types.py
@@ -55,3 +55,6 @@ NOTIFICATION_SESSION = "notification.session"
 AGENT_MESSAGE_REQUESTED = "agent.message_requested"
 AGENT_MESSAGE_COMPLETED = "agent.message_completed"
 AGENT_MESSAGE_FAILED = "agent.message_failed"
+
+# 会话生命周期事件
+SESSION_CREATED = "session.created"

--- a/agentos/kernel/runtime/agent_message_coordinator.py
+++ b/agentos/kernel/runtime/agent_message_coordinator.py
@@ -14,6 +14,7 @@ from agentos.kernel.events.types import (
     AGENT_MESSAGE_REQUESTED,
     AGENT_STEP_COMPLETED,
     ERROR_RAISED,
+    SESSION_CREATED,
     USER_TURN_CANCEL_REQUESTED,
 )
 from agentos.kernel.runtime.message_record import MessageRecord
@@ -226,22 +227,34 @@ class AgentMessageCoordinator:
                     },
                 )
             else:
+                meta = {
+                    "title": f"[send_message] {message[:30]}",
+                    "record_id": record.id,
+                    "send_depth": depth,
+                    "send_chain": send_chain + [target_id],
+                    "parent_turn_id": parent_turn_id,
+                    "parent_tool_call_id": parent_tool_call_id,
+                    "message_trace_id": record.id,
+                }
                 turn_id = await self._agent_runtime.spawn_agent_session(
                     agent_id=target_id,
                     session_id=child_session_id,
                     user_input=message,
                     parent_session_id=parent_session_id,
                     trace_id=record.id,
-                    meta={
-                        "title": f"[send_message] {message[:30]}",
-                        "record_id": record.id,
-                        "send_depth": depth,
-                        "send_chain": send_chain + [target_id],
-                        "parent_turn_id": parent_turn_id,
-                        "parent_tool_call_id": parent_tool_call_id,
-                        "message_trace_id": record.id,
-                    },
+                    meta=meta,
                 )
+                # 通知前端有新 session 创建
+                await self._bus.publish(EventEnvelope(
+                    type=SESSION_CREATED,
+                    session_id=child_session_id,
+                    source="agent_message_coordinator",
+                    payload={
+                        "session_id": child_session_id,
+                        "agent_id": target_id,
+                        "meta": meta,
+                    },
+                ))
         except Exception as exc:  # noqa: BLE001
             logger.exception("agent_message 启动目标会话失败 record=%s", record.id)
             await self.cancel_message(


### PR DESCRIPTION
## Summary

- 后端 `spawn_agent_session` 后发布 `SESSION_CREATED` 事件，WebSocket 广播 `session_list_changed` 到所有客户端
- 前端收到 `session_list_changed` 事件时自动刷新 session 列表
- 前端切换 agent 时也刷新 session 列表作为兜底

**改动文件（5 个）：**
- `types.py` — 新增 `SESSION_CREATED` 事件类型
- `agent_message_coordinator.py` — spawn 后发布事件
- `websocket_channel.py` — 映射为 `session_list_changed` 并广播
- `ChatSessionContext.tsx` — 监听 `session_list_changed` 刷新列表
- `chat/page.tsx` — 切换 agent 时刷新列表

## Test plan

- [ ] Agent A 调用 send_message 给 Agent B 后，切换到 Agent B 能立即看到新对话
- [ ] 不切换 agent 时，session 列表也能实时更新
- [x] 单元测试通过（无新增失败）

🤖 Generated with [Claude Code](https://claude.com/claude-code)