### PR TITLE
fix: 工作台最近对话选中高亮与消息界面统一

### DIFF
--- a/agentos/app/web/components/workbench/LeftNav.tsx
+++ b/agentos/app/web/components/workbench/LeftNav.tsx
@@ -45,7 +45,7 @@ function RecentChatItem({
       className={cn(
         'flex items-start gap-2.5 px-3 py-3 rounded-xl cursor-pointer transition-all group',
         isActive
-          ? 'bg-primary/8 text-foreground border border-primary/20 shadow-sm'
+          ? 'bg-blue-100 text-foreground border border-blue-200 shadow-sm dark:bg-blue-900/40 dark:border-blue-800'
           : 'hover:bg-muted/60 text-foreground/80 border border-transparent',
       )}
     >


### PR DESCRIPTION
## Summary
- 工作台左侧最近对话列表选中项改为蓝色背景高亮（`bg-blue-100`），与消息界面风格一致

🤖 Generated with [Claude Code](https://claude.com/claude-code)