### PR TITLE
fix: json-viewer 背景色改为浅灰色

### DIFF
--- a/agentos/app/web/app/globals.css
+++ b/agentos/app/web/app/globals.css
@@ -351,7 +351,7 @@ body {
 .json-viewer {
   margin: 0;
   padding: 8px;
-  background: rgba(0, 0, 0, 0.3);
+  background: #F8FAFC;
   border-radius: 4px;
   overflow-x: auto;
   font-size: 10px;
@@ -359,7 +359,7 @@ body {
 }
 
 .json-viewer code {
-  color: #93c5fd;
+  color: #334155;
   font-family: 'JetBrains Mono', monospace;
 }
 

--- a/agentos/app/web/components/workbench/LeftNav.tsx
+++ b/agentos/app/web/components/workbench/LeftNav.tsx
@@ -45,7 +45,7 @@ function RecentChatItem({
       className={cn(
         'flex items-start gap-2.5 px-3 py-3 rounded-xl cursor-pointer transition-all group',
         isActive
-          ? 'bg-primary/8 text-foreground border border-primary/20 shadow-sm'
+          ? 'bg-blue-100 text-foreground border border-blue-200 shadow-sm dark:bg-blue-900/40 dark:border-blue-800'
           : 'hover:bg-muted/60 text-foreground/80 border border-transparent',
       )}
     >


### PR DESCRIPTION
## Summary
- json-viewer 背景色从深色 `rgba(0,0,0,0.3)` 改为浅灰 `#F8FAFC`
- 文字颜色从蓝色 `#93c5fd` 改为深灰 `#334155`

🤖 Generated with [Claude Code](https://claude.com/claude-code)