### PR TITLE
fix: 对话区顶部显示 session_id

### DIFF
--- a/agentos/app/web/app/chat/page.tsx
+++ b/agentos/app/web/app/chat/page.tsx
@@ -404,6 +404,13 @@ function ChatContent() {
             </div>
           ) : (
             <>
+              {/* Session ID 栏 */}
+              {currentSessionId && (
+                <div className="px-4 py-1.5 border-b border-border/40 flex items-center">
+                  <span className="text-[10px] text-muted-foreground/60">Session: </span>
+                  <span className="text-[10px] text-muted-foreground/60 font-mono select-all">{currentSessionId}</span>
+                </div>
+              )}
               {/* 消息区 */}
               <div className="flex-1 overflow-y-auto p-4 md:p-8">
                 {messages.length === 0 ? (

--- a/agentos/app/web/components/chat/ChatPanel.tsx
+++ b/agentos/app/web/components/chat/ChatPanel.tsx
@@ -76,6 +76,13 @@ export function ChatPanel({ defaultAgentId, emptyState, hideAgentSelector, lockA
 
   return (
     <div className="flex flex-col h-full">
+      {/* Session ID 栏 */}
+      {currentSessionId && (
+        <div className="px-4 py-1.5 border-b border-border/40 flex items-center">
+          <span className="text-[10px] text-muted-foreground/60">Session: </span>
+          <span className="text-[10px] text-muted-foreground/60 font-mono select-all">{currentSessionId}</span>
+        </div>
+      )}
       {/* 消息区域 */}
       <div className="flex-1 overflow-y-auto p-4 md:p-8">
         {messages.length === 0 && !currentSessionId ? (


### PR DESCRIPTION
## Summary
- 消息界面和工作台聊天区顶部均显示当前 session_id
- 无 session 时不显示
- 点击仅选中 id 部分，方便复制

🤖 Generated with [Claude Code](https://claude.com/claude-code)