### PR TITLE
feat: Setup 流程优化 + 必配清单检查

### DIFF
--- a/agentos/app/web/app/chat/page.tsx
+++ b/agentos/app/web/app/chat/page.tsx
@@ -1,6 +1,7 @@
 'use client';
 
-import { Suspense, useState, useEffect, useCallback, useRef } from 'react';
+import { Suspense, useState, useEffect, useCallback, useRef, useMemo } from 'react';
+import { useSearchParams } from 'next/navigation';
 import {
   Loader2, Bot, MessageSquare, Plus, Search, RefreshCw, Trash2,
 } from 'lucide-react';
@@ -169,11 +170,15 @@ function ChatContent() {
     cleanupEmptySession,
   } = useChatSession();
 
+  const searchParams = useSearchParams();
+  const agentFromUrl = searchParams.get('agent');
+
   const [agents, setAgents] = useState<AgentBrief[]>([]);
   const [loadingAgents, setLoadingAgents] = useState(true);
-  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(null);
+  const [selectedAgentId, setSelectedAgentId] = useState<string | null>(agentFromUrl);
   const [searchQuery, setSearchQuery] = useState('');
   const chatEndRef = useRef<HTMLDivElement>(null);
+  const requiredCheckDone = useRef(false);
 
   const loadAgents = useCallback(async () => {
     setLoadingAgents(true);
@@ -239,6 +244,39 @@ function ChatContent() {
         a.description.toLowerCase().includes(searchQuery.toLowerCase()),
       )
     : agents;
+
+  // 必配清单检查：进入 system-admin 新 session 时自动发送缺失配置提醒
+  useEffect(() => {
+    if (requiredCheckDone.current) return;
+    if (selectedAgentId !== 'system-admin') return;
+    if (!agentFromUrl || agentFromUrl !== 'system-admin') return;
+    if (!wsConnected || agents.length === 0) return;
+
+    // 仅在没有现有 session 时触发（首次进入）
+    const existingSessions = sessionsByAgent['system-admin'] || [];
+    if (existingSessions.length > 0) return;
+
+    requiredCheckDone.current = true;
+
+    (async () => {
+      try {
+        const res = await authFetch(`${API_BASE}/api/config/required-check`);
+        const data = await res.json();
+        const missing: string[] = [];
+        for (const [, info] of Object.entries(data)) {
+          const item = info as { configured: boolean; message: string };
+          if (!item.configured) missing.push(item.message);
+        }
+        if (missing.length > 0) {
+          const text = `以下系统配置尚未完成，请帮我配置：\n${missing.map((m, i) => `${i + 1}. ${m}`).join('\n')}`;
+          startNewChat();
+          sendMessage(text, [], 'system-admin');
+        }
+      } catch (e) {
+        console.error('必配清单检查失败:', e);
+      }
+    })();
+  }, [selectedAgentId, agentFromUrl, wsConnected, agents, sessionsByAgent, startNewChat, sendMessage]);
 
   const handleNewChat = () => {
     if (!selectedAgentId) return;

--- a/agentos/app/web/app/setup/page.tsx
+++ b/agentos/app/web/app/setup/page.tsx
@@ -257,7 +257,7 @@ export default function SetupPage() {
 
       // 标记已完成配置，避免 ProtectedRoute 再次跳回 setup
       sessionStorage.setItem('llm_just_configured', '1');
-      router.push('/');
+      router.push('/chat?agent=system-admin');
     } catch (e) {
       console.error('保存配置失败:', e);
       setSubmitError('保存配置失败，请稍后重试');

--- a/agentos/interfaces/http/config_api.py
+++ b/agentos/interfaces/http/config_api.py
@@ -67,6 +67,41 @@ async def get_llm_presets():
     return {"categories": LLM_PROVIDER_CATEGORIES}
 
 
+@router.get("/required-check")
+async def check_required_config(request: Request):
+    """检查必配项状态：搜索工具（至少一个）、邮箱配置"""
+    cfg = request.app.state.config
+
+    # 搜索工具：serper / brave / baidu / tavily 至少配一个
+    search_keys = [
+        "tools.serper_search.api_key",
+        "tools.brave_search.api_key",
+        "tools.baidu_search.api_key",
+        "tools.tavily_search.api_key",
+    ]
+    search_configured = any(
+        bool(cfg.get(k, "")) and not str(cfg.get(k, "")).startswith("${")
+        for k in search_keys
+    )
+
+    # 邮箱：enabled + smtp_host + username 都有值
+    email_enabled = cfg.get("tools.email.enabled", False)
+    email_smtp = cfg.get("tools.email.smtp_host", "")
+    email_user = cfg.get("tools.email.username", "")
+    email_configured = bool(email_enabled and email_smtp and email_user)
+
+    return {
+        "search_tool": {
+            "configured": search_configured,
+            "message": "搜索工具未配置（serper/brave/baidu/tavily 至少需要配置一个）",
+        },
+        "email": {
+            "configured": email_configured,
+            "message": "邮箱未配置（需要配置 SMTP/IMAP 信息）",
+        },
+    }
+
+
 @router.post("/list-models")
 async def list_models(body: ListModelsBody):
     """通过 OpenAI 兼容的 GET /models 接口获取可用模型列表"""

--- a/config_example.yml
+++ b/config_example.yml
@@ -153,7 +153,7 @@ agents:
     skills: []
 
   system-admin:
-    name: SystemAdmin
+    name: 系统运维管理员
     description: 系统运维管理员，负责 AgentOS 平台的配置管理、Agent 管理、工具管理、Skill/Plugin 安装等运维操作
     temperature: 0.2
     tools: [read_file, write_file, bash_command]

--- a/docs/superpowers/specs/2026-03-22-setup-flow-and-required-config-design.md
+++ b/docs/superpowers/specs/2026-03-22-setup-flow-and-required-config-design.md
@@ -1,0 +1,84 @@
+# Setup 流程优化 + 必配清单设计
+
+## 概述
+
+优化首次配置体验：Setup 完成后直接跳转到 system-admin 对话；system-admin 默认中文名称；进入 system-admin 时自动检查必配项并发送提醒。
+
+## 需求
+
+1. **system-admin 名称** — 默认 Name 改为"系统运维管理员"
+2. **Setup 后跳转** — 完成 LLM 配置后跳转到 `/chat?agent=system-admin`（而非首页）
+3. **必配清单检查** — 进入 system-admin 对话时，前端检查必配项，缺失则自动作为用户消息发送
+
+## 详细设计
+
+### 1. system-admin 名称
+
+修改 `config_example.yml` 中 `agents.system-admin.name` 为 `系统运维管理员`。
+
+### 2. Setup 后跳转
+
+**文件**: `agentos/app/web/app/setup/page.tsx`
+
+将 `router.push('/')` 改为 `router.push('/chat?agent=system-admin')`（两处：完成配置按钮和跳过按钮）。
+
+**文件**: `agentos/app/web/app/chat/page.tsx`
+
+当前 chat 页面不读取 `?agent=` query param。需要添加：
+- 读取 `searchParams.get('agent')`
+- 如果有值，初始化 `selectedAgentId` 为该值
+
+### 3. 必配清单
+
+#### 3.1 后端 API
+
+**新增端点**: `GET /api/config/required-check`
+
+**文件**: `agentos/interfaces/http/config_api.py`
+
+返回各必配项状态：
+
+```json
+{
+  "search_tool": {
+    "configured": false,
+    "message": "搜索工具未配置（serper/brave/baidu/tavily 至少需要配置一个）"
+  },
+  "email": {
+    "configured": false,
+    "message": "邮箱未配置（需要配置 SMTP/IMAP 信息）"
+  }
+}
+```
+
+检查逻辑：
+- **搜索工具**: 检查 `tools.serper_search.api_key`、`tools.brave_search.api_key`、`tools.baidu_search.api_key`、`tools.tavily_search.api_key` 至少一个有值
+- **邮箱**: 检查 `tools.email.enabled == true` 且 `smtp_host`、`username` 有值
+
+#### 3.2 前端自动消息
+
+**文件**: `agentos/app/web/app/chat/page.tsx`
+
+当 `selectedAgentId === 'system-admin'` 且创建新 session 时：
+1. 调用 `GET /api/config/required-check`
+2. 收集所有 `configured === false` 的项
+3. 如果有缺失，拼接消息文本并自动作为用户输入发送：
+
+```
+以下系统配置尚未完成，请帮我配置：
+1. 搜索工具未配置（serper/brave/baidu/tavily 至少需要配置一个）
+2. 邮箱未配置（需要配置 SMTP/IMAP 信息）
+```
+
+4. 如果全部已配置，不发送任何自动消息
+
+**触发时机**: 仅在进入 system-admin 且是新 session（无历史消息）时检查一次。切换回已有 session 不重复触发。
+
+## 文件变更清单
+
+| 操作 | 文件 |
+|------|------|
+| 修改 | `config_example.yml` — system-admin name |
+| 修改 | `agentos/app/web/app/setup/page.tsx` — 跳转目标 |
+| 修改 | `agentos/app/web/app/chat/page.tsx` — 读取 agent query param + 必配清单检查 |
+| 修改 | `agentos/interfaces/http/config_api.py` — 新增 required-check 端点 |

--- a/tests/unit/test_config_api.py
+++ b/tests/unit/test_config_api.py
@@ -146,3 +146,24 @@ def test_list_models_accepts_openai_compatible_provider_keys(client, monkeypatch
         "models": [{"id": "MiniMax-M2.7-highspeed", "owned_by": "minimax"}],
     }
     mocked.assert_awaited_once_with("sk-minimax", "https://api.minimax.chat/v1")
+
+
+# ── 必配清单检查 ──
+
+
+def test_required_check_all_missing(client):
+    """未配置搜索工具和邮箱时，两项都返回 configured=false"""
+    resp = client.get("/api/config/required-check")
+    assert resp.status_code == 200
+    data = resp.json()
+    assert data["search_tool"]["configured"] is False
+    assert data["email"]["configured"] is False
+
+
+def test_required_check_search_configured(client, app):
+    """配置了搜索工具 API key 后，search_tool 返回 configured=true"""
+    app.state.config.data.setdefault("tools", {}).setdefault("serper_search", {})["api_key"] = "sk-test"
+    resp = client.get("/api/config/required-check")
+    data = resp.json()
+    assert data["search_tool"]["configured"] is True
+    assert data["email"]["configured"] is False


### PR DESCRIPTION
## Summary

- system-admin 默认 Name 改为"系统运维管理员"
- Setup 完成后跳转到 `/chat?agent=system-admin`（而非首页）
- Chat 页面支持 `?agent=` query param 预选 agent
- 新增 `GET /api/config/required-check` 端点，检查搜索工具和邮箱配置状态
- 进入 system-admin 新 session 时自动检查必配项，缺失则作为用户消息发送提醒

## Test plan

- [x] 后端 required-check API 测试通过（9/9）
- [ ] 手动验证：完成 Setup 后自动跳转到 system-admin 对话
- [ ] 手动验证：进入 system-admin 时，未配置项自动作为消息发送
- [ ] 手动验证：已配置所有必配项时，不发送自动消息

🤖 Generated with [Claude Code](https://claude.com/claude-code)