### PR TITLE
fix: code review 修复 + CLAUDE.md 文档更新

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -104,6 +104,13 @@ user.input → agent.step_started → llm.call_requested → llm.call_completed
 - **ToolRuntime**: 工具执行，监听 `tool.call_requested`，发布 `tool.call_completed`
 - **TitleRuntime**: 自动生成会话标题
 
+### 配置管理
+
+- **ConfigManager** (`platform/config/config_manager.py`): 统一配置写入入口，负责持久化 YAML、刷新内存、发布 `config.updated` 事件
+- **ConfigFileWatcher**: 监听 config.yml 外部变更，通过 watchdog 实现
+- 配置变更通过 EventBus 通知下游模块（LLMFactory、AgentRegistry、MemoryManager）自动刷新
+- Gateway 将 `config.*` 事件广播给所有 WebSocket 客户端
+
 ### 状态管理
 
 - **SessionStateStore**: 内存状态管理（Turn、Message、工具调用状态）
@@ -111,9 +118,12 @@ user.input → agent.step_started → llm.call_requested → llm.call_completed
 
 ### 工具系统
 
-启动时注册 10 个工具（9 个在 `_register_builtin()` + 1 个在 Gateway 启动时注册）：
+启动时注册核心工具（在 `_register_builtin()` 中），加上运行时条件注册的工具：
+
+**核心工具（始终注册）：**
 - `bash_command`: 执行 shell 命令
 - `serper_search`: 网络搜索（需 SERPER_API_KEY）
+- `image_search`: 图片搜索（需 SERPER_API_KEY）
 - `brave_search`: 网络搜索（需 BRAVE_SEARCH_API_KEY）
 - `baidu_search`: 网络搜索（需 BAIDU_APPBUILDER_API_KEY）
 - `tavily_search`: 网络搜索（需 TAVILY_API_KEY）
@@ -121,9 +131,13 @@ user.input → agent.step_started → llm.call_requested → llm.call_completed
 - `read_file`: 读取文件
 - `write_file`: 写入文件
 - `create_agent`: 动态创建新 Agent 配置
-- `send_message`: 向其他 Agent 发送消息（Gateway 启动时注册）
+- `ask_user`: 向用户提问（需确认/输入时使用）
 
-邮件工具（`send_email`、`list_emails` 等 6 个）定义在 `email.py` 中但未默认注册，需配置后手动启用。
+**条件注册的工具：**
+- `send_message`: 向其他 Agent 发送消息（`delegation.enabled=true` 时注册）
+- `cron_tool`: 定时任务管理（`cron.enabled=true` 时注册）
+- `memory_search`: 记忆搜索（`memory.enabled=true` 且 `memory.search.enabled=true` 时注册）
+- 邮件工具（6 个）: `send_email`、`list_emails`、`read_email`、`download_attachment`、`mark_email`、`search_emails`（`tools.email.enabled=true` 时注册）
 
 工具注册在 `ToolRegistry`，搜索工具在未配置对应 API key 时不暴露给 LLM。
 
@@ -163,10 +177,11 @@ QQ 邮箱:
 
 ### Skills 系统
 
-Skills 是声明式任务编排机制（`agentos/capabilities/skills/`），16 个内置 skills 包括：
-- 文档处理: `pdf_to_markdown`, `docx_to_markdown`, `xlsx_to_markdown`
-- 前端开发: `design_frontend`, `test_frontend`
-- Skill 管理: `create_skill`
+Skills 是声明式任务编排机制（`agentos/capabilities/skills/`），23 个内置 skills 包括：
+- PPT 制作流水线: `ppt-superpower`, `ppt-research-pack`, `ppt-storyboard`, `ppt-page-plan` 等 13 个
+- 飞书集成: `feishu-doc`, `feishu-drive`, `feishu-perm`, `feishu-wiki`
+- 搜索增强: `research-union`, `union-search-plus`
+- 系统运维: `system-admin-skill`
 
 Skills 通过 YAML 配置定义，支持多步骤编排和条件分支。
 
@@ -180,12 +195,16 @@ llm:
     openai:
       api_key: ${OPENAI_API_KEY}
       base_url: ${OPENAI_BASE_URL}
-  default_model: gpt_4o_mini    # 引用 llm.models 中的 key
+  models:
+    gpt-4o-mini:
+      provider: openai
+      model_id: gpt-4o-mini
+  default_model: gpt-4o-mini    # 引用 llm.models 中的 key
 
 agent:
-  model: gpt_4o_mini            # 引用 llm.models 中的 key
   temperature: 0.2
   system_prompt: "你是一个有工具能力的AI助手，请在必要时调用工具。"
+  # 注意: agent.model 已废弃，使用 llm.default_model 代替
 
 tools:
   serper_search:
@@ -196,6 +215,8 @@ tools:
     api_key: ${BRAVE_API_KEY}
   tavily_search:
     api_key: ${TAVILY_API_KEY}
+  email:
+    enabled: false              # 启用后注册邮件工具
 ```
 
 ### 配置加载
@@ -294,28 +315,36 @@ scripts/               # 开发脚本
 
 ## 版本信息
 
-当前版本: v0.5
+当前版本: v1.2
+
+v1.2 新增:
+- ConfigManager 统一配置管理与事件驱动联动
+- 配置变更文件监听（watchdog）
+- 上下文压缩（Turn 级 + 合并压缩）
+- Secret 迁移工具（明文 → keyring）
+- LLM 页面单项编辑功能
+- Setup 流程优化（完成后跳转 system-admin）
+- 必配清单检查 API
+
+v1.0 新增:
+- 多 Agent 架构（AgentRegistry、Agent-to-Agent 消息）
+- 飞书 Channel 插件
+- Token 认证
+- 记忆系统（v0.6）
+- Cron 定时任务 + Heartbeat 心跳巡检（v0.8）
+- 插件系统（v0.9）
 
 v0.5 新增:
 - 代码架构重组（backend/app/ → agentos/ 六层架构）
 - 移除 Workflow 功能模块
-- 完整测试覆盖（734 tests）
-
-v0.4 新增:
-- Skills 系统（16 个内置 skills）
-- Skills 配置管理
 
 v0.2 新增:
 - Gateway 架构
 - CLI/TUI 客户端
 - 自动标题生成
-- 工具结果截断
-- 消息归一化
 
 暂不支持:
 - 流式响应
-- Token 管理
-- 用户认证
 - 沙箱执行
 
 # 其他

--- a/agentos/capabilities/tools/registry.py
+++ b/agentos/capabilities/tools/registry.py
@@ -43,14 +43,18 @@ class ToolRegistry:
             WriteFileTool(),
             CreateAgentTool(),
             AskUserTool(),
-            SendEmailTool(),
-            ListEmailsTool(),
-            ReadEmailTool(),
-            DownloadAttachmentTool(),
-            MarkEmailTool(),
-            SearchEmailsTool(),
         ]:
             self.register(tool)
+        if config.get("tools.email.enabled", False):
+            for tool in [
+                SendEmailTool(),
+                ListEmailsTool(),
+                ReadEmailTool(),
+                DownloadAttachmentTool(),
+                MarkEmailTool(),
+                SearchEmailsTool(),
+            ]:
+                self.register(tool)
 
     def register(self, tool: Tool) -> None:
         # 注册工具到内存字典，供 ToolRuntime 查找。

--- a/agentos/kernel/runtime/workers/llm_worker.py
+++ b/agentos/kernel/runtime/workers/llm_worker.py
@@ -31,7 +31,7 @@ _LLM_DEBUG = os.environ.get("AGENTOS_DEBUG_LLM", "").strip() not in ("", "0", "f
 def _get_debug_base() -> Path:
     """获取 debug 日志根目录: $AGENTOS_HOME/logs/debug/llm"""
     from agentos.platform.config.workspace import resolve_agentos_home
-    return resolve_agentos_home() / "logs" / "debug" / "llm"
+    return resolve_agentos_home(config) / "logs" / "debug" / "llm"
 
 
 def _save_llm_debug(

--- a/agentos/kernel/runtime/workers/tool_worker.py
+++ b/agentos/kernel/runtime/workers/tool_worker.py
@@ -5,7 +5,7 @@ import json
 import logging
 import uuid
 from pathlib import Path
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Any
 
 from agentos.platform.config.config import config
 from agentos.kernel.events.bus import PrivateEventBus
@@ -51,7 +51,7 @@ class ToolSessionWorker(SessionWorker):
         elif event.type == USER_QUESTION_ANSWERED:
             self._resolve_question(event)
 
-    def _truncate_result(self, result: any, tool_call_id: str) -> any:
+    def _truncate_result(self, result: Any, tool_call_id: str) -> Any:
         """Token 截断：统一控制传给 LLM 的结果长度"""
         result_str = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False)
 

--- a/tests/unit/test_agent_worker.py
+++ b/tests/unit/test_agent_worker.py
@@ -437,7 +437,7 @@ class TestHandleLLMCompleted:
             tool_registry,
             memory_manager=fake_memory_manager,
         )
-        agent_cfg = AgentConfig(id="planner", name="planner", provider="openai", model="gpt-4o-mini")
+        agent_cfg = AgentConfig(id="planner", name="planner", model="claude-sonnet")
         worker = AgentSessionWorker("s1", private_bus, runtime, agent_config=agent_cfg)
 
         await repo.create_session("s1", meta={"agent_id": "planner"})
@@ -480,8 +480,8 @@ class TestHandleLLMCompleted:
         assert any(evt.type == AGENT_STEP_COMPLETED for evt in collected)
         fake_memory_manager.summarize_turn.assert_awaited_once_with(
             state.messages,
-            provider="openai",
-            model="gpt-4o-mini",
+            provider="anthropic",
+            model="claude-sonnet-4-6",
             agent_id="planner",
         )
 

--- a/tests/unit/test_memory_summarize.py
+++ b/tests/unit/test_memory_summarize.py
@@ -81,7 +81,7 @@ class TestSummarizeTurn:
 
         await manager.summarize_turn(messages)
 
-        memory_path = workspace / "memory.md"
+        memory_path = workspace / "MEMORY.md"
         assert memory_path.exists()
         content = memory_path.read_text(encoding="utf-8")
         assert "需求：实现登录功能" in content
@@ -111,7 +111,7 @@ class TestSummarizeTurn:
         await manager.summarize_turn(messages)
         await manager.summarize_turn(messages)
 
-        content = (workspace / "memory.md").read_text(encoding="utf-8")
+        content = (workspace / "MEMORY.md").read_text(encoding="utf-8")
         assert content.count("---") == 2
 
     @pytest.mark.asyncio
@@ -123,13 +123,13 @@ class TestSummarizeTurn:
 
         await manager_no_llm.summarize_turn(messages)
 
-        assert not (workspace / "memory.md").exists()
+        assert not (workspace / "MEMORY.md").exists()
 
     @pytest.mark.asyncio
     async def test_summarize_turn_skips_empty_conversation(self, manager, workspace):
         await manager.summarize_turn([{"role": "system", "content": "系统提示"}])
 
-        assert not (workspace / "memory.md").exists()
+        assert not (workspace / "MEMORY.md").exists()
 
     @pytest.mark.asyncio
     async def test_summarize_turn_skips_empty_summary(self, manager, workspace, mock_llm_factory):
@@ -142,7 +142,7 @@ class TestSummarizeTurn:
             ]
         )
 
-        assert not (workspace / "memory.md").exists()
+        assert not (workspace / "MEMORY.md").exists()
 
     @pytest.mark.asyncio
     async def test_summarize_turn_passes_provider_and_model(self, manager, mock_llm_factory):

--- a/tests/unit/test_tool_registry.py
+++ b/tests/unit/test_tool_registry.py
@@ -1,4 +1,6 @@
 """T04: ToolRegistry 注册/发现"""
+from unittest.mock import patch
+
 from agentos.capabilities.tools.registry import ToolRegistry
 from agentos.capabilities.tools.base import Tool, ToolRiskLevel
 
@@ -23,17 +25,31 @@ class TestToolRegistry:
         assert r.get("write_file") is not None
         assert r.get("ask_user") is not None
 
-    def test_email_tools_registered(self):
+    def test_email_tools_not_registered_by_default(self):
+        """email 工具默认不注册（tools.email.enabled=False）"""
         r = ToolRegistry()
         names = {t["name"] for t in r.as_llm_tools()}
-        assert {
-            "send_email",
-            "list_emails",
-            "read_email",
-            "download_attachment",
-            "mark_email",
-            "search_emails",
-        }.issubset(names)
+        email_tools = {"send_email", "list_emails", "read_email", "download_attachment", "mark_email", "search_emails"}
+        assert email_tools.isdisjoint(names)
+
+    def test_email_tools_registered_when_enabled(self):
+        """tools.email.enabled=True 时 email 工具应注册"""
+        from agentos.platform.config.config import config
+        original = config.data["tools"]["email"]["enabled"]
+        try:
+            config.data["tools"]["email"]["enabled"] = True
+            r = ToolRegistry()
+            names = {t["name"] for t in r.as_llm_tools()}
+            assert {
+                "send_email",
+                "list_emails",
+                "read_email",
+                "download_attachment",
+                "mark_email",
+                "search_emails",
+            }.issubset(names)
+        finally:
+            config.data["tools"]["email"]["enabled"] = original
 
     def test_register_custom(self):
         r = ToolRegistry()


### PR DESCRIPTION
## Summary

全面 code review 后的 bug 修复和文档更新。

### Bug 修复
- **C1**: `llm_worker.py` `resolve_agentos_home()` 传入 config 参数，避免 debug 日志写入错误路径
- **I1**: email 工具改为仅在 `tools.email.enabled=true` 时注册（此前无论是否配置都注册）
- **M1**: memory summarize 测试修正文件名 `memory.md` → `MEMORY.md`
- **M2**: agent worker 测试修正 model key 和 provider 期望值
- **M4**: `tool_worker.py` 类型提示 `any` → `Any`

### CLAUDE.md 更新
- 工具列表：10 个 → 实际的核心工具 + 条件注册工具分类
- Skill 数量：16 → 23，更新分类描述
- 配置示例：移除废弃的 `agent.model`，添加 `llm.models` 示例
- 版本信息：v0.5 → v1.2
- 新增 ConfigManager 架构描述

## Test plan

- [x] 修复的 3 个测试现在全部通过（agent_worker、memory_summarize、tool_registry）
- [x] 全量单元测试：979 passed, 4 failed (pre-existing env issues), 33 skipped
- [x] 测试失败数从 7 → 4（修复了 3 个）

🤖 Generated with [Claude Code](https://claude.com/claude-code)