### PR TITLE
refactor: 移除 AgentConfig.provider 废弃字段

### DIFF
--- a/agentos/app/web/app/agents/[id]/page.tsx
+++ b/agentos/app/web/app/agents/[id]/page.tsx
@@ -18,7 +18,6 @@ interface AgentDetail {
   name: string;
   status: string;
   description: string;
-  provider: string;
   model: string;
   systemPrompt: string;
   temperature: number;
@@ -252,7 +251,7 @@ export default function AgentDetailPage() {
             </CardHeader>
             <CardContent>
               <div className={`text-4xl font-black capitalize ${agent.status === 'active' ? 'text-green-600 dark:text-green-500' : ''}`}>{agent.status}</div>
-              <p className="text-sm font-medium text-muted-foreground mt-2">{agent.provider} / {agent.model}</p>
+              <p className="text-sm font-medium text-muted-foreground mt-2">{agent.model}</p>
             </CardContent>
           </Card>
           <Card className="shadow-lg border-border/60">

--- a/agentos/app/web/app/agents/page.tsx
+++ b/agentos/app/web/app/agents/page.tsx
@@ -16,7 +16,6 @@ interface Agent {
   name: string;
   status: string;
   description: string;
-  provider: string;
   model: string;
   sessionCount: number;
   toolCount: number;
@@ -287,7 +286,6 @@ function CreateAgentModal({ onClose, onCreated }: { onClose: () => void; onCreat
   const [formId, setFormId] = useState('');
   const [formName, setFormName] = useState('');
   const [formDesc, setFormDesc] = useState('');
-  const [formProvider, setFormProvider] = useState('openai');
   const [formModel, setFormModel] = useState('gpt-4o-mini');
   const [formTemp, setFormTemp] = useState('0.2');
   const [formPrompt, setFormPrompt] = useState('');
@@ -309,7 +307,6 @@ function CreateAgentModal({ onClose, onCreated }: { onClose: () => void; onCreat
           id: formId.trim(),
           name: formName.trim(),
           description: formDesc.trim(),
-          provider: formProvider.trim() || undefined,
           model: formModel.trim() || undefined,
           temperature: parseFloat(formTemp) || 0.2,
           system_prompt: formPrompt,
@@ -355,11 +352,7 @@ function CreateAgentModal({ onClose, onCreated }: { onClose: () => void; onCreat
             <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">描述</label>
             <Input value={formDesc} onChange={e => setFormDesc(e.target.value)} placeholder="负责搜索和研究的 Agent" />
           </div>
-          <div className="grid grid-cols-3 gap-4">
-            <div className="space-y-2">
-              <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Provider</label>
-              <Input value={formProvider} onChange={e => setFormProvider(e.target.value)} />
-            </div>
+          <div className="grid grid-cols-2 gap-4">
             <div className="space-y-2">
               <label className="text-sm font-medium leading-none peer-disabled:cursor-not-allowed peer-disabled:opacity-70">Model</label>
               <Input value={formModel} onChange={e => setFormModel(e.target.value)} />

--- a/agentos/capabilities/agents/config.py
+++ b/agentos/capabilities/agents/config.py
@@ -19,8 +19,7 @@ class AgentConfig:
     description: str = ""                             # 描述（用于 LLM 选择委托目标）
 
     # LLM 配置
-    provider: str = "openai"                          # LLM 提供商
-    model: str = "gpt-4o-mini"                        # 模型名称
+    model: str = "gpt-4o-mini"                        # 模型名称（引用 llm.models 中的 key，provider 由 resolve_model 动态解析）
     temperature: float = 0.2                          # 温度参数
     max_tokens: int | None = None                     # 最大 token 数
     extra_body: dict[str, Any] = field(default_factory=dict)  # 透传给 LLM API 的额外参数
@@ -47,7 +46,6 @@ class AgentConfig:
             "id": self.id,
             "name": self.name,
             "description": self.description,
-            "provider": self.provider,
             "model": self.model,
             "temperature": self.temperature,
             "max_tokens": self.max_tokens,
@@ -71,7 +69,6 @@ class AgentConfig:
             id=data["id"],
             name=data.get("name", data["id"]),
             description=data.get("description", ""),
-            provider=data.get("provider", "openai"),
             model=data.get("model", "gpt-4o-mini"),
             temperature=data.get("temperature", 0.2),
             max_tokens=data.get("max_tokens"),

--- a/agentos/capabilities/agents/registry.py
+++ b/agentos/capabilities/agents/registry.py
@@ -122,7 +122,6 @@ class AgentRegistry:
             id=agent_id,
             name=agent_dict.get("name", agent_id.replace("-", " ").title() if agent_id != "default" else "Default Agent"),
             description=agent_dict.get("description", "默认 AI Agent" if agent_id == "default" else ""),
-            provider="",  # provider 现在由 model key 通过 resolve_model 动态解析
             model=agent_dict.get("model", ""),
             temperature=agent_dict.get("temperature", fallback.get("temperature", 0.2)),
             max_tokens=agent_dict.get("max_tokens"),

--- a/agentos/capabilities/tools/orchestration.py
+++ b/agentos/capabilities/tools/orchestration.py
@@ -43,10 +43,6 @@ class CreateAgentTool(Tool):
                 "type": "string",
                 "description": "系统提示词，定义 Agent 的角色和行为",
             },
-            "provider": {
-                "type": "string",
-                "description": "LLM 提供商，如 'openai'、'anthropic'，留空则继承默认配置",
-            },
             "model": {
                 "type": "string",
                 "description": "模型名称，如 'gpt-4o-mini'、'claude-3-haiku'，留空则继承默认配置",
@@ -91,7 +87,6 @@ class CreateAgentTool(Tool):
 
         # 从 default Agent 继承未指定的配置
         default = registry.get("default")
-        provider = kwargs.get("provider") or (default.provider if default else "openai")
         model = kwargs.get("model") or (default.model if default else "gpt-4o-mini")
         temperature = kwargs.get("temperature")
         if temperature is None:
@@ -101,7 +96,6 @@ class CreateAgentTool(Tool):
             id=agent_id,
             name=name,
             description=str(kwargs.get("description", "")),
-            provider=provider,
             model=model,
             temperature=float(temperature),
             system_prompt=str(kwargs.get("system_prompt", "")),
@@ -118,7 +112,6 @@ class CreateAgentTool(Tool):
             "success": True,
             "agent_id": agent_id,
             "name": name,
-            "provider": provider,
             "model": model,
             "message": f"Agent '{name}' (id={agent_id}) 已创建成功，可通过 send_message 或新会话使用",
         }

--- a/agentos/interfaces/http/agents.py
+++ b/agentos/interfaces/http/agents.py
@@ -100,7 +100,6 @@ def _build_agent_detail(agent_cfg: AgentConfig, request: Request) -> dict[str, A
         "name": agent_cfg.name,
         "status": "active" if agent_cfg.enabled else "disabled",
         "description": agent_cfg.description,
-        "provider": agent_cfg.provider,
         "model": agent_cfg.model,
         "systemPrompt": agent_cfg.system_prompt,
         "temperature": agent_cfg.temperature,
@@ -129,7 +128,6 @@ class AgentPreferences(BaseModel):
 class AgentConfigUpdate(BaseModel):
     name: str | None = None
     description: str | None = None
-    provider: str | None = None
     model: str | None = None
     temperature: float | None = None
     max_tokens: int | None = None
@@ -144,7 +142,6 @@ class AgentCreate(BaseModel):
     id: str
     name: str
     description: str = ""
-    provider: str | None = None
     model: str | None = None
     temperature: float | None = None
     max_tokens: int | None = None
@@ -252,7 +249,6 @@ async def create_agent(body: AgentCreate, request: Request):
         id=body.id,
         name=body.name,
         description=body.description,
-        provider=body.provider or (default.provider if default else "openai"),
         model=body.model or (default.model if default else "gpt-4o-mini"),
         temperature=body.temperature if body.temperature is not None else (default.temperature if default else 0.2),
         max_tokens=body.max_tokens,
@@ -286,8 +282,6 @@ async def update_agent_config(agent_id: str, body: AgentConfigUpdate, request: R
         updates["name"] = body.name
     if body.description is not None:
         updates["description"] = body.description
-    if body.provider is not None:
-        updates["provider"] = body.provider
     if body.model is not None:
         updates["model"] = body.model
     if body.temperature is not None:

--- a/tests/unit/test_orchestration_tool.py
+++ b/tests/unit/test_orchestration_tool.py
@@ -33,7 +33,6 @@ def registry_with_default(agent_registry):
     default = AgentConfig(
         id="default",
         name="Default Agent",
-        provider="openai",
         model="gpt-4o",
         temperature=0.5,
     )
@@ -117,7 +116,7 @@ class TestExecuteSuccess:
         assert registered.name == "New Agent"
 
     async def test_inherit_from_default(self, tool, registry_with_default):
-        """未指定 provider/model/temperature 时从 default Agent 继承"""
+        """未指定 model/temperature 时从 default Agent 继承"""
         result = await tool.execute(
             id="new-agent",
             name="New Agent",
@@ -125,7 +124,6 @@ class TestExecuteSuccess:
         )
 
         assert result["success"] is True
-        assert result["provider"] == "openai"
         assert result["model"] == "gpt-4o"
 
         # 验证 temperature 继承自 default
@@ -133,17 +131,15 @@ class TestExecuteSuccess:
         assert created.temperature == 0.5
 
     async def test_custom_params_override_default(self, tool, registry_with_default):
-        """显式指定 provider/model 时覆盖默认值"""
+        """显式指定 model 时覆盖默认值"""
         result = await tool.execute(
             id="custom",
             name="Custom Agent",
-            provider="anthropic",
             model="claude-3-haiku",
             temperature=0.8,
             _agent_registry=registry_with_default,
         )
 
-        assert result["provider"] == "anthropic"
         assert result["model"] == "claude-3-haiku"
 
         created = registry_with_default.get("custom")
@@ -157,7 +153,6 @@ class TestExecuteSuccess:
             _agent_registry=agent_registry,
         )
 
-        assert result["provider"] == "openai"
         assert result["model"] == "gpt-4o-mini"
 
     async def test_tools_and_delegation(self, tool, agent_registry):


### PR DESCRIPTION
## Summary

`AgentConfig.provider` 字段已无实际作用——运行时通过 `config.resolve_model(model_key)` 动态解析 provider，但前端仍显示旧值（默认 `"openai"`），导致信息不一致。

彻底移除 `provider` 字段：
- `AgentConfig` dataclass（含 `to_dict` / `from_dict`）
- Agent API 响应和请求体
- `create_agent` 工具
- 前端 Agent 详情页和创建表单

## Test plan

- [x] 51 个相关测试全部通过
- [ ] 手动验证：Agent 详情页只显示 model，不再显示 provider

🤖 Generated with [Claude Code](https://claude.com/claude-code)