### PR TITLE
fix: 修复消息显示顺序 — tool_call 堆积问题

### DIFF
--- a/agentos/app/web/contexts/ChatSessionContext.tsx
+++ b/agentos/app/web/contexts/ChatSessionContext.tsx
@@ -137,6 +137,25 @@ export function ChatSessionProvider({ children }: { children: React.ReactNode })
       if (turnId) {
         const existingIndex = prev.findIndex((item) => item.role === 'assistant' && item.turnId === turnId);
         if (existingIndex !== -1) {
+          // 检查该 assistant 消息之后是否已经插入了 tool 消息
+          // 如果有，说明这是新一轮 LLM 调用的结果，应创建新消息而不是覆盖
+          const hasToolAfter = prev.slice(existingIndex + 1).some((m) => m.role === 'tool');
+          if (hasToolAfter) {
+            // 新一轮 LLM 思考，追加新的 assistant 消息
+            return [
+              ...prev,
+              {
+                id: makeId(),
+                role: 'assistant' as const,
+                content,
+                timestamp: Date.now(),
+                turnId: `${turnId}_${Date.now()}`,
+                thinkingContent,
+                thinkingState,
+              },
+            ];
+          }
+          // 同一轮 LLM 调用的流式更新，原地更新
           const next = [...prev];
           next[existingIndex] = {
             ...next[existingIndex],

--- a/agentos/app/web/contexts/ChatSessionContext.tsx
+++ b/agentos/app/web/contexts/ChatSessionContext.tsx
@@ -394,12 +394,19 @@ export function ChatSessionProvider({ children }: { children: React.ReactNode })
       }
       case 'turn_completed': {
         const final = String(payload.final_response || '');
-        const turnId = typeof payload.turn_id === 'string' ? payload.turn_id : undefined;
         if (final) {
-          upsertAssistantMessage({
-            turnId,
-            content: final,
-            thinkingState: 'collapsed',
+          // 更新最后一条 assistant 消息的内容（不创建新消息）
+          setMessages((prev) => {
+            // 从后往前找最后一条 assistant 消息
+            for (let i = prev.length - 1; i >= 0; i--) {
+              if (prev[i].role === 'assistant') {
+                const next = [...prev];
+                next[i] = { ...next[i], content: final, thinkingState: 'collapsed' };
+                return next;
+              }
+            }
+            // 没找到 assistant 消息（理论上不会发生），追加一条
+            return [...prev, { id: makeId(), role: 'assistant', content: final, timestamp: Date.now() }];
           });
         }
         setIsTyping(false);

--- a/agentos/app/web/lib/chatTypes.ts
+++ b/agentos/app/web/lib/chatTypes.ts
@@ -148,6 +148,21 @@ export function rebuildMessagesFromEvents(events: Record<string, unknown>[]): Ch
       rebuilt.push({ id: makeId(), role: 'user', content: String(payload.content || ''), timestamp: Date.now() });
       continue;
     }
+    if (eventType === 'llm.call_result') {
+      const content = String(payload.content || '');
+      const thinkingContent = String(payload.reasoning_content || '');
+      if (content || thinkingContent) {
+        rebuilt.push({
+          id: makeId(),
+          role: 'assistant',
+          content,
+          timestamp: Date.now(),
+          thinkingContent: thinkingContent || undefined,
+          thinkingState: thinkingContent ? 'collapsed' : undefined,
+        });
+      }
+      continue;
+    }
     if (eventType === 'tool.call_requested') {
       const toolInfo: ToolInfo = {
         name: String(payload.tool_name || ''),


### PR DESCRIPTION
## Summary

修复 tool_call 和 tool_response 全部堆积在一起的问题。实际流程应为 `thinking → tool_call → tool_response → thinking → tool_call → tool_response`，但之前所有 tool 消息被堆在一起，中间的思考过程丢失。

### 根因

`upsertAssistantMessage` 按 `turnId` 查找已有 assistant 消息并原地更新。同一 turn 内多次 LLM 调用共享 `turnId`，导致第二次 LLM 的 thinking 覆盖第一次的 assistant 消息。

### 修复

**实时消息（ChatSessionContext.tsx）：**
- 当 `llm_result` 到达时，检查同 `turnId` 的 assistant 消息之后是否已有 tool 消息
- 如果有 → 创建新 assistant 消息（新一轮 LLM 思考）
- 如果没有 → 原地更新（同一轮流式更新）

**历史消息（chatTypes.ts）：**
- `rebuildMessagesFromEvents` 新增 `llm.call_result` 事件处理
- 历史加载时也能正确显示中间思考过程

## Test plan

- [ ] 手动验证：发送需要多轮工具调用的请求，确认消息顺序为 thinking → tools → thinking → tools
- [ ] 手动验证：切换到已有会话，确认历史消息顺序正确

🤖 Generated with [Claude Code](https://claude.com/claude-code)