### PR TITLE
feat: 思考过程按 turn 分组显示，tool call 单行折叠

### DIFF
--- a/agentos/app/web/app/chat/page.tsx
+++ b/agentos/app/web/app/chat/page.tsx
@@ -10,7 +10,9 @@ import { authFetch, API_BASE } from '@/lib/authFetch';
 import { useChatSession } from '@/contexts/ChatSessionContext';
 import { type SessionItem, type ContextFileRef, getAgentId, getTitle, timeLabel } from '@/lib/chatTypes';
 import { MessageBubble } from '@/components/chat/MessageBubble';
+import { ThinkingProcess } from '@/components/chat/ThinkingProcess';
 import { TypingIndicator } from '@/components/chat/TypingIndicator';
+import { type ChatMessage } from '@/lib/chatTypes';
 import { ChatInput } from '@/components/chat/ChatInput';
 import { InteractionDialog } from '@/components/chat/QuestionDialog';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
@@ -142,6 +144,73 @@ function SessionListItem({
       </button>
     </div>
   );
+}
+
+/* ── 消息按 Turn 分组 ── */
+
+type MessageGroup =
+  | { type: 'single'; key: string; messages: ChatMessage[] }
+  | { type: 'turn'; key: string; thinkingSteps: ChatMessage[]; finalAnswer: ChatMessage | null };
+
+/**
+ * 将扁平消息列表按 turn 分组：
+ * - user/system 消息作为独立项
+ * - 同一 turn 内的 assistant+tool 消息分组：
+ *   最后一条 assistant 是最终回复，其余（中间 assistant thinking + tool calls）归入思考过程
+ */
+function groupMessagesByTurn(messages: ChatMessage[]): MessageGroup[] {
+  const groups: MessageGroup[] = [];
+  let i = 0;
+
+  while (i < messages.length) {
+    const msg = messages[i];
+
+    // user/system 消息独立显示
+    if (msg.role === 'user' || msg.role === 'system') {
+      groups.push({ type: 'single', key: msg.id, messages: [msg] });
+      i++;
+      continue;
+    }
+
+    // 从当前位置收集连续的 assistant+tool 消息（同一个 turn 的处理过程）
+    const turnMessages: ChatMessage[] = [];
+    while (i < messages.length && (messages[i].role === 'assistant' || messages[i].role === 'tool')) {
+      turnMessages.push(messages[i]);
+      i++;
+    }
+
+    // 只有一条 assistant 且没有 tool → 直接显示
+    if (turnMessages.length === 1 && turnMessages[0].role === 'assistant') {
+      groups.push({ type: 'single', key: turnMessages[0].id, messages: turnMessages });
+      continue;
+    }
+
+    // 多条消息：找最后一条 assistant 作为最终回复
+    let finalAnswerIdx = -1;
+    for (let j = turnMessages.length - 1; j >= 0; j--) {
+      if (turnMessages[j].role === 'assistant') {
+        finalAnswerIdx = j;
+        break;
+      }
+    }
+
+    const finalAnswer = finalAnswerIdx >= 0 ? turnMessages[finalAnswerIdx] : null;
+    const thinkingSteps = turnMessages.filter((_, idx) => idx !== finalAnswerIdx);
+
+    // 如果没有 thinking steps，直接显示 final answer
+    if (thinkingSteps.length === 0 && finalAnswer) {
+      groups.push({ type: 'single', key: finalAnswer.id, messages: [finalAnswer] });
+    } else {
+      groups.push({
+        type: 'turn',
+        key: `turn-${turnMessages[0].id}`,
+        thinkingSteps,
+        finalAnswer,
+      });
+    }
+  }
+
+  return groups;
 }
 
 /* ── 主体内容 ── */
@@ -458,7 +527,22 @@ function ChatContent() {
                   </div>
                 ) : (
                   <>
-                    {messages.map(msg => <MessageBubble key={msg.id} msg={msg} />)}
+                    {groupMessagesByTurn(messages).map(group => {
+                      if (group.type === 'single') {
+                        return <MessageBubble key={group.messages[0].id} msg={group.messages[0]} />;
+                      }
+                      // turn group: thinking steps + final answer
+                      return (
+                        <div key={group.key}>
+                          {group.thinkingSteps.length > 0 && (
+                            <ThinkingProcess steps={group.thinkingSteps} />
+                          )}
+                          {group.finalAnswer && (
+                            <MessageBubble msg={group.finalAnswer} />
+                          )}
+                        </div>
+                      );
+                    })}
                     {isTyping && <TypingIndicator />}
                     <div ref={chatEndRef} />
                   </>

--- a/agentos/app/web/app/chat/page.tsx
+++ b/agentos/app/web/app/chat/page.tsx
@@ -155,8 +155,9 @@ type MessageGroup =
 /**
  * 将扁平消息列表按 turn 分组：
  * - user/system 消息作为独立项
- * - 同一 turn 内的 assistant+tool 消息分组：
- *   最后一条 assistant 是最终回复，其余（中间 assistant thinking + tool calls）归入思考过程
+ * - 连续的 assistant+tool 消息分组为一个 turn：
+ *   所有中间 assistant thinking、tool calls、以及最终 assistant 的 thinking
+ *   都归入思考过程块；只有最终 assistant 的 answer 内容正常展示
  */
 function groupMessagesByTurn(messages: ChatMessage[]): MessageGroup[] {
   const groups: MessageGroup[] = [];
@@ -179,8 +180,9 @@ function groupMessagesByTurn(messages: ChatMessage[]): MessageGroup[] {
       i++;
     }
 
-    // 只有一条 assistant 且没有 tool → 直接显示
-    if (turnMessages.length === 1 && turnMessages[0].role === 'assistant') {
+    // 只有一条 assistant 且没有 tool 且没有 thinking → 直接显示
+    if (turnMessages.length === 1 && turnMessages[0].role === 'assistant' &&
+        !turnMessages[0].thinkingContent) {
       groups.push({ type: 'single', key: turnMessages[0].id, messages: turnMessages });
       continue;
     }
@@ -195,17 +197,33 @@ function groupMessagesByTurn(messages: ChatMessage[]): MessageGroup[] {
     }
 
     const finalAnswer = finalAnswerIdx >= 0 ? turnMessages[finalAnswerIdx] : null;
-    const thinkingSteps = turnMessages.filter((_, idx) => idx !== finalAnswerIdx);
 
-    // 如果没有 thinking steps，直接显示 final answer
-    if (thinkingSteps.length === 0 && finalAnswer) {
-      groups.push({ type: 'single', key: finalAnswer.id, messages: [finalAnswer] });
+    // 思考过程 = 所有非 finalAnswer 的消息 + finalAnswer 的 thinking 部分
+    // 如果 finalAnswer 有 thinkingContent，为它创建一个"仅 thinking"的虚拟消息放入思考过程
+    const thinkingSteps: ChatMessage[] = turnMessages.filter((_, idx) => idx !== finalAnswerIdx);
+    if (finalAnswer?.thinkingContent) {
+      thinkingSteps.push({
+        ...finalAnswer,
+        id: `${finalAnswer.id}_thinking`,
+        content: '',  // 不显示 answer 内容，只显示 thinking
+      });
+    }
+
+    // finalAnswer 去掉 thinking（已放入思考过程块）
+    const cleanFinalAnswer = finalAnswer ? {
+      ...finalAnswer,
+      thinkingContent: undefined,
+      thinkingState: undefined,
+    } : null;
+
+    if (thinkingSteps.length === 0 && cleanFinalAnswer) {
+      groups.push({ type: 'single', key: cleanFinalAnswer.id, messages: [cleanFinalAnswer] });
     } else {
       groups.push({
         type: 'turn',
         key: `turn-${turnMessages[0].id}`,
         thinkingSteps,
-        finalAnswer,
+        finalAnswer: cleanFinalAnswer,
       });
     }
   }

--- a/agentos/app/web/components/chat/ThinkingProcess.tsx
+++ b/agentos/app/web/components/chat/ThinkingProcess.tsx
@@ -1,0 +1,157 @@
+'use client';
+
+import { useState } from 'react';
+import { ChevronDown, ChevronRight, Wrench, Brain } from 'lucide-react';
+import { type ChatMessage, formatArgs } from '@/lib/chatTypes';
+import { isJsonLike, stringifyContent } from '@/components/chat/messageContent';
+import { MarkdownRenderer } from '@/components/chat/MarkdownRenderer';
+import { MarkdownContent } from './MarkdownContent';
+import { resolveAssistantDisplayContent } from '@/lib/assistantThink';
+
+/**
+ * 思考过程区块：将一个 turn 内的中间消息（thinking + tool calls）
+ * 折叠显示在一个带最大高度的容器中。
+ */
+export function ThinkingProcess({ steps }: { steps: ChatMessage[] }) {
+  const [expanded, setExpanded] = useState(false);
+
+  if (steps.length === 0) return null;
+
+  return (
+    <div className="max-w-4xl mx-auto my-2">
+      <div className="ml-14 rounded-xl border border-border/60 bg-muted/30 overflow-hidden">
+        {/* 标题栏 */}
+        <button
+          type="button"
+          onClick={() => setExpanded(prev => !prev)}
+          className="flex w-full items-center gap-2 px-4 py-2.5 text-left text-xs font-medium text-muted-foreground hover:text-foreground transition-colors"
+        >
+          <ChevronDown
+            size={14}
+            className={`shrink-0 transition-transform duration-200 ${expanded ? 'rotate-0' : '-rotate-90'}`}
+          />
+          <Brain size={14} className="text-amber-500" />
+          <span>思考过程</span>
+          <span className="text-[10px] text-muted-foreground/60 ml-1">
+            ({steps.filter(s => s.role === 'tool').length} 次工具调用)
+          </span>
+        </button>
+
+        {/* 内容区 */}
+        {expanded && (
+          <div className="border-t border-border/40 max-h-[400px] overflow-y-auto">
+            <div className="px-4 py-2 space-y-1">
+              {steps.map(step => (
+                step.role === 'tool'
+                  ? <CompactToolCall key={step.id} msg={step} />
+                  : <ThinkingText key={step.id} msg={step} />
+              ))}
+            </div>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+/** 中间 assistant 思考文本（简洁显示） */
+function ThinkingText({ msg }: { msg: ChatMessage }) {
+  const { thinkContent, answerContent } = resolveAssistantDisplayContent(
+    msg.content || '', msg.thinkingContent
+  );
+  const text = thinkContent || answerContent;
+  if (!text) return null;
+
+  return (
+    <div className="text-xs text-muted-foreground py-1.5 pl-1 border-l-2 border-amber-500/30 ml-1">
+      <div className="pl-3 max-h-[120px] overflow-y-auto">
+        <MarkdownContent content={text} />
+      </div>
+    </div>
+  );
+}
+
+/** 单行 tool call，点击展开 Payload/Output */
+function CompactToolCall({ msg }: { msg: ChatMessage }) {
+  const [expanded, setExpanded] = useState(false);
+  const ti = msg.toolInfo;
+  const toolName = ti?.name || msg.name || 'tool';
+  const status = ti?.status || 'completed';
+  const success = ti?.success !== false;
+
+  return (
+    <div className="py-0.5">
+      {/* 单行摘要 */}
+      <button
+        type="button"
+        onClick={() => setExpanded(prev => !prev)}
+        className="flex items-center gap-2 w-full text-left text-xs py-1 px-1 rounded hover:bg-muted/50 transition-colors"
+      >
+        <ChevronRight
+          size={12}
+          className={`shrink-0 text-muted-foreground transition-transform duration-150 ${expanded ? 'rotate-90' : ''}`}
+        />
+        <Wrench size={12} className={status === 'running' ? 'text-amber-500' : success ? 'text-green-500' : 'text-red-500'} />
+        <span className="font-mono text-foreground/80">{toolName}</span>
+        <span className={`text-[10px] ml-auto ${status === 'running' ? 'text-amber-500' : success ? 'text-green-500/70' : 'text-red-500/70'}`}>
+          {status === 'running' ? '执行中...' : success ? '✓' : '✗'}
+        </span>
+      </button>
+
+      {/* 展开后：Payload 和 Output */}
+      {expanded && ti && (
+        <div className="ml-6 mt-1 mb-2 space-y-1">
+          <CollapsibleSection title="Payload" content={ti.arguments} />
+          {ti.status === 'completed' && (
+            ti.error
+              ? <CollapsibleSection title="Output" content={ti.error} isError />
+              : <CollapsibleSection title="Output" content={ti.result} />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}
+
+/** 可折叠的 Payload/Output 子区块 */
+function CollapsibleSection({
+  title, content, isError = false,
+}: {
+  title: string;
+  content: unknown;
+  isError?: boolean;
+}) {
+  const [open, setOpen] = useState(false);
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen(prev => !prev)}
+        className="flex items-center gap-1.5 text-[11px] font-medium text-muted-foreground hover:text-foreground transition-colors"
+      >
+        <ChevronRight
+          size={11}
+          className={`transition-transform duration-150 ${open ? 'rotate-90' : ''}`}
+        />
+        {title}
+      </button>
+      {open && (
+        <div className={`mt-1 rounded-md border p-2 text-xs max-h-[200px] overflow-y-auto ${
+          isError ? 'border-red-500/20 bg-red-500/5 text-red-600 dark:text-red-400' : 'border-border bg-muted/30'
+        }`}>
+          {isJsonLike(content) ? (
+            <pre className="whitespace-pre-wrap break-all font-mono text-[11px]">
+              <code>{formatArgs(content)}</code>
+            </pre>
+          ) : (
+            <MarkdownRenderer
+              className="chat-markdown chat-markdown--detail"
+              content={stringifyContent(content)}
+            />
+          )}
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

重构消息渲染：将 turn 内的中间消息（thinking + tool calls）折叠为"思考过程"区块，最终回复正常展示。

### 改动前
```
[assistant thinking1]     ← 独立消息
[tool: search]            ← 独立消息，完整展开
[tool: fetch]             ← 独立消息，完整展开
[assistant thinking2]     ← 独立消息
[tool: write_file]        ← 独立消息，完整展开
[assistant 最终回复]      ← 独立消息
```

### 改动后
```
┌─ 思考过程（可折叠，max-height 400px）──┐
│  💭 thinking1                           │
│  🔧 search ✓    ▸ Payload / Output     │
│  🔧 fetch ✓     ▸ Payload / Output     │
│  💭 thinking2                           │
│  🔧 write_file ✓                       │
└─────────────────────────────────────────┘
[assistant 最终回复]  ← 正常展示
```

### 新增文件
- `components/chat/ThinkingProcess.tsx` — 思考过程区块 + 紧凑 tool call + 三级折叠

### 修改文件
- `app/chat/page.tsx` — 新增 `groupMessagesByTurn()` 分组逻辑，替换扁平渲染

## Test plan

- [ ] 手动验证：发送多轮工具调用请求，确认思考过程折叠显示
- [ ] 手动验证：展开思考过程，确认 tool call 单行显示
- [ ] 手动验证：点击 tool call 展开 Payload/Output
- [ ] 手动验证：单条 assistant 回复（无 tool call）正常显示不受影响

🤖 Generated with [Claude Code](https://claude.com/claude-code)