### PR TITLE
feat: 思考过程和 tool_call payload 默认展开显示

### DIFF
--- a/agentos/app/web/components/chat/MessageBubble.tsx
+++ b/agentos/app/web/components/chat/MessageBubble.tsx
@@ -9,7 +9,7 @@ import { resolveAssistantDisplayContent } from '@/lib/assistantThink';
 import { MarkdownContent } from './MarkdownContent';
 
 export function MessageBubble({ msg }: { msg: ChatMessage }) {
-  const [showArgs, setShowArgs] = useState(false);
+  const [showArgs, setShowArgs] = useState(true);
   const [showResult, setShowResult] = useState(false);
   const parsedAssistantContent = useMemo(
     () => msg.role === 'assistant'
@@ -17,11 +17,11 @@ export function MessageBubble({ msg }: { msg: ChatMessage }) {
       : { answerContent: '', thinkContent: '' },
     [msg.content, msg.role, msg.thinkingContent],
   );
-  const [showThink, setShowThink] = useState(msg.thinkingState === 'streaming');
+  const [showThink, setShowThink] = useState(true);
 
   useEffect(() => {
     if (msg.role !== 'assistant') return;
-    setShowThink(msg.thinkingState === 'streaming');
+    setShowThink(true);
   }, [msg.id, msg.role, msg.thinkingState]);
 
   if (msg.role === 'system') {


### PR DESCRIPTION
## Summary
- 消息的思考过程（thinking）默认展开显示
- Tool call 的 payload 默认展开显示
- 用户仍可手动点击折叠

## Test plan
- [ ] 打开聊天页面，发送消息，确认思考过程默认展开
- [ ] 确认 tool call 的 payload 默认展开
- [ ] 点击折叠按钮，确认可以手动折叠

🤖 Generated with [Claude Code](https://claude.com/claude-code)