### PR TITLE
feat: 模型配置新增 max_tokens 字段 & 修复 session 选中高亮

### DIFF
--- a/agentos/app/web/app/chat/page.tsx
+++ b/agentos/app/web/app/chat/page.tsx
@@ -116,13 +116,13 @@ function SessionListItem({
       className={cn(
         'flex items-center gap-2.5 px-3 py-2.5 mx-2 rounded-xl cursor-pointer transition-all text-sm group relative',
         'animate-in fade-in slide-in-from-left-2 duration-200',
-        isActive ? 'bg-primary/8 text-foreground shadow-sm border border-primary/15' : 'hover:bg-muted/60 text-foreground/80 border border-transparent',
+        isActive ? 'bg-blue-100 dark:bg-blue-900/40 text-foreground shadow-md' : 'hover:bg-muted/60 text-foreground/80 border border-transparent',
       )}
       style={{ animationDelay: `${index * 30}ms`, animationFillMode: 'both' }}
     >
       <MessageSquare className={cn(
         'w-4 h-4 shrink-0',
-        isActive ? 'text-primary' : 'text-muted-foreground',
+        isActive ? 'text-blue-500' : 'text-muted-foreground',
       )} />
       <div className="flex-1 min-w-0">
         <div className="truncate font-medium text-xs">{getTitle(session.meta)}</div>

--- a/agentos/app/web/app/llms/page.tsx
+++ b/agentos/app/web/app/llms/page.tsx
@@ -25,6 +25,7 @@ interface ModelConfig {
   provider: string;
   model_id: string;
   timeout: number;
+  max_tokens: number;
   max_output_tokens: number;
 }
 
@@ -118,6 +119,7 @@ export default function LlmsPage() {
         provider: draft.provider,
         model_id: draft.model_id,
         timeout: draft.timeout,
+        max_tokens: draft.max_tokens,
         max_output_tokens: draft.max_output_tokens,
       },
     ]));
@@ -362,7 +364,8 @@ export default function LlmsPage() {
         provider: providerName,
         model_id: '',
         timeout: 60,
-        max_output_tokens: 8192,
+        max_tokens: 128000,
+        max_output_tokens: 16384,
         name: nextName,
       };
     if (editingAll && globalDraft) {
@@ -593,6 +596,7 @@ export default function LlmsPage() {
         provider: draft.provider,
         model_id: draft.model_id,
         timeout: draft.timeout,
+        max_tokens: draft.max_tokens,
         max_output_tokens: draft.max_output_tokens,
       }),
     });
@@ -951,12 +955,20 @@ export default function LlmsPage() {
                                 onChange={(value) => updateModelField(modelName, 'timeout', parseInt(value, 10) || 60)}
                               />
                               <FieldInput
+                                label="Max Tokens"
+                                type="number"
+                                value={String(getModelDraft(modelName).max_tokens || 128000)}
+                                dataTestId={`llm-max-tokens-input-${modelName}`}
+                                disabled={!isModelEditable(modelName)}
+                                onChange={(value) => updateModelField(modelName, 'max_tokens', parseInt(value, 10) || 128000)}
+                              />
+                              <FieldInput
                                 label="Max Output Tokens"
                                 type="number"
-                                value={String(getModelDraft(modelName).max_output_tokens || 8192)}
+                                value={String(getModelDraft(modelName).max_output_tokens || 16384)}
                                 dataTestId={`llm-max-output-tokens-input-${modelName}`}
                                 disabled={!isModelEditable(modelName)}
-                                onChange={(value) => updateModelField(modelName, 'max_output_tokens', parseInt(value, 10) || 8192)}
+                                onChange={(value) => updateModelField(modelName, 'max_output_tokens', parseInt(value, 10) || 16384)}
                               />
                             </div>
                             <div className="flex items-start justify-end md:justify-center">
@@ -1140,7 +1152,8 @@ function normalizeModels(input: Record<string, unknown>): Record<string, ModelCo
           provider: String(model.provider || ''),
           model_id: String(model.model_id || ''),
           timeout: Number(model.timeout || 60),
-          max_output_tokens: Number(model.max_output_tokens || 8192),
+          max_tokens: Number(model.max_tokens || 128000),
+          max_output_tokens: Number(model.max_output_tokens || 16384),
         },
       ];
     }),
@@ -1191,6 +1204,7 @@ function buildModelPayloadsFromDrafts(models: Record<string, ModelDraft>): Recor
         provider: draft.provider,
         model_id: draft.model_id,
         timeout: draft.timeout,
+        max_tokens: draft.max_tokens,
         max_output_tokens: draft.max_output_tokens,
       },
     ]),

--- a/agentos/app/web/app/settings/page.tsx
+++ b/agentos/app/web/app/settings/page.tsx
@@ -25,6 +25,7 @@ interface ModelConfig {
   provider: string;
   model_id: string;
   timeout: number;
+  max_tokens: number;
   max_output_tokens: number;
 }
 
@@ -160,7 +161,7 @@ export default function SettingsPage() {
     const firstProvider = Object.keys(providers)[0] || '';
     setModels(prev => ({
       ...prev,
-      [name]: { provider: firstProvider, model_id: '', timeout: 60, max_output_tokens: 8192 },
+      [name]: { provider: firstProvider, model_id: '', timeout: 60, max_tokens: 128000, max_output_tokens: 16384 },
     }));
     setExpandedModels(prev => ({ ...prev, [name]: true }));
     setNewModelName('');
@@ -350,8 +351,10 @@ export default function SettingsPage() {
                               onChange={v => updateModel(name, 'model_id', v)} />
                             <FieldInput label="Timeout (s)" value={String(models[name]?.timeout || 60)} type="number"
                               onChange={v => updateModel(name, 'timeout', parseInt(v) || 60)} />
-                            <FieldInput label="Max Output Tokens" value={String(models[name]?.max_output_tokens || 8192)} type="number"
-                              onChange={v => updateModel(name, 'max_output_tokens', parseInt(v) || 8192)} />
+                            <FieldInput label="Max Tokens" value={String(models[name]?.max_tokens || 128000)} type="number"
+                              onChange={v => updateModel(name, 'max_tokens', parseInt(v) || 128000)} />
+                            <FieldInput label="Max Output Tokens" value={String(models[name]?.max_output_tokens || 16384)} type="number"
+                              onChange={v => updateModel(name, 'max_output_tokens', parseInt(v) || 16384)} />
                           </div>
                         </div>
                       )}

--- a/agentos/interfaces/http/config_api.py
+++ b/agentos/interfaces/http/config_api.py
@@ -45,7 +45,8 @@ class ModelUpdateBody(BaseModel):
     provider: str
     model_id: str
     timeout: int = 60
-    max_output_tokens: int = 8192
+    max_tokens: int = 128000
+    max_output_tokens: int = 16384
 
 
 @router.get("/secret")
@@ -181,6 +182,7 @@ async def update_llm_model(model_name: str, body: ModelUpdateBody, request: Requ
         "provider": body.provider,
         "model_id": body.model_id,
         "timeout": body.timeout,
+        "max_tokens": body.max_tokens,
         "max_output_tokens": body.max_output_tokens,
     }
     llm_section["models"] = models

--- a/agentos/kernel/runtime/workers/agent_worker.py
+++ b/agentos/kernel/runtime/workers/agent_worker.py
@@ -81,6 +81,13 @@ class AgentSessionWorker(SessionWorker):
             return self.agent_config.temperature
         return config.get("agent.temperature", 0.2)
 
+    def _get_max_tokens(self) -> int:
+        """获取 max_output_tokens：agent 级别覆盖 model 级别"""
+        if self.agent_config and self.agent_config.max_tokens:
+            return self.agent_config.max_tokens
+        model_key = self._get_model_key()
+        return config.get_model_max_output_tokens(model_key)
+
     def _get_extra_body(self) -> dict:
         """获取 extra_body：agent 级别覆盖 model 级别"""
         model_key = self._get_model_key()
@@ -296,6 +303,7 @@ class AgentSessionWorker(SessionWorker):
                     "messages": messages,
                     "tools": self._get_filtered_tools(),
                     "temperature": self._get_temperature(),
+                    "max_tokens": self._get_max_tokens(),
                     "extra_body": self._get_extra_body(),
                 },
             )
@@ -493,6 +501,7 @@ class AgentSessionWorker(SessionWorker):
                     "messages": state.messages,
                     "tools": self._get_filtered_tools(),
                     "temperature": self._get_temperature(),
+                    "max_tokens": self._get_max_tokens(),
                     "extra_body": self._get_extra_body(),
                 },
             )

--- a/agentos/platform/config/config.py
+++ b/agentos/platform/config/config.py
@@ -70,25 +70,29 @@ DEFAULT_CONFIG: dict[str, Any] = {
                 "provider": "openai",
                 "model_id": "gpt-5.4",
                 "timeout": 60,
-                "max_output_tokens": 8192,
+                "max_tokens": 128000,
+                "max_output_tokens": 16384,
             },
             "claude-sonnet": {
                 "provider": "anthropic",
                 "model_id": "claude-sonnet-4-6",
                 "timeout": 60,
-                "max_output_tokens": 8192,
+                "max_tokens": 128000,
+                "max_output_tokens": 16384,
             },
             "claude-opus": {
                 "provider": "anthropic",
                 "model_id": "claude-opus-4-6",
                 "timeout": 60,
-                "max_output_tokens": 8192,
+                "max_tokens": 128000,
+                "max_output_tokens": 16384,
             },
             "gemini-pro": {
                 "provider": "gemini",
                 "model_id": "gemini-2.5-pro",
                 "timeout": 120,
-                "max_output_tokens": 8192,
+                "max_tokens": 128000,
+                "max_output_tokens": 16384,
             },
         },
         "default_model": "mock",  # 引用 llm.models 中的 key
@@ -527,6 +531,25 @@ class Config:
         # 都找不到，返回 mock
         logger.warning("未知的模型 key: %s，使用 mock provider", model_key)
         return "mock", model_key
+
+    def get_model_max_output_tokens(self, model_key: str | None = None) -> int:
+        """获取模型配置中的 max_output_tokens（最大输出 token 数）。
+
+        Args:
+            model_key: llm.models 中的 key，为 None 时使用 llm.default_model。
+        Returns:
+            max_output_tokens，无配置时返回默认值 16384
+        """
+        if not model_key:
+            model_key = self.get("llm.default_model", "mock")
+        models = self.get("llm.models", {})
+        if model_key in models:
+            return int(models[model_key].get("max_output_tokens", 16384))
+        # 向后兼容：反查 model_id
+        for _key, entry in models.items():
+            if isinstance(entry, dict) and entry.get("model_id") == model_key:
+                return int(entry.get("max_output_tokens", 16384))
+        return 16384
 
     def get_model_extra_body(self, model_key: str | None = None) -> dict:
         """获取模型配置中的 extra_body（透传给 LLM API 请求体的额外参数）。


### PR DESCRIPTION
## Summary
- 模型配置新增 `max_tokens`（上下文窗口，默认 128000）和 `max_output_tokens`（默认 16384），agent_worker 发布 LLM 调用时传入 max_tokens
- 前端 LLM/Settings 页面同步新增 Max Tokens 输入框
- 修复 chat 页面选中 session 时背景色不高亮的问题，与 agent 选中样式一致

## Test plan
- [ ] 启动前端，在 LLM 页面确认新增的 Max Tokens 输入框显示正常，默认值为 128000
- [ ] 在 Settings 页面确认 Max Tokens 输入框同步显示
- [ ] 验证 LLM 调用日志中 max_tokens 字段正确传递
- [ ] 在 chat 页面选中 session，确认背景色高亮效果

🤖 Generated with [Claude Code](https://claude.com/claude-code)