### PR TITLE
fix: 修复消息显示 — 思考过程丢失和工具调用堆积

### DIFF
--- a/agentos/adapters/llm/providers/openai_provider.py
+++ b/agentos/adapters/llm/providers/openai_provider.py
@@ -55,7 +55,9 @@ class OpenAIProvider(LLMProvider):
                     "arguments": parsed,
                 })
 
-        return {
+        # 提取 reasoning_content（DeepSeek、MiniMax 等 OpenAI 兼容模型的思考过程）
+        reasoning_content = getattr(message, "reasoning_content", None) or ""
+        result: dict[str, Any] = {
             "content": message.content or "",
             "tool_calls": tool_calls,
             "finish_reason": "tool_calls" if tool_calls else (choice.finish_reason or "stop"),
@@ -65,6 +67,9 @@ class OpenAIProvider(LLMProvider):
                 "total_tokens": getattr(response.usage, "total_tokens", 0),
             },
         }
+        if reasoning_content:
+            result["reasoning_details"] = [{"type": "thinking", "thinking": reasoning_content}]
+        return result
 
     def _normalize_messages(self, messages: list[dict[str, Any]]) -> list[dict[str, Any]]:
         normalized: list[dict[str, Any]] = []

--- a/agentos/app/web/contexts/ChatSessionContext.tsx
+++ b/agentos/app/web/contexts/ChatSessionContext.tsx
@@ -334,7 +334,10 @@ export function ChatSessionProvider({ children }: { children: React.ReactNode })
         const content = String(payload.content || '');
         const turnId = typeof payload.turn_id === 'string' ? payload.turn_id : undefined;
         const thinkingContent = extractThinkContentFromReasoningDetails(payload.reasoning_details);
-        if (content || thinkingContent) {
+        const hasToolCalls = Array.isArray(payload.tool_calls) && payload.tool_calls.length > 0;
+        // 有内容、有思考过程、或有工具调用时，都创建 assistant 消息
+        // 确保工具调用前的思考过程不会丢失
+        if (content || thinkingContent || hasToolCalls) {
           upsertAssistantMessage({
             turnId,
             content,

--- a/agentos/app/web/lib/chatTypes.ts
+++ b/agentos/app/web/lib/chatTypes.ts
@@ -1,4 +1,5 @@
 // 共享类型定义和工具函数
+import { extractThinkContentFromReasoningDetails } from './assistantThink';
 
 export interface ToolInfo {
   name: string;
@@ -149,9 +150,13 @@ export function rebuildMessagesFromEvents(events: Record<string, unknown>[]): Ch
       continue;
     }
     if (eventType === 'llm.call_result') {
-      const content = String(payload.content || '');
-      const thinkingContent = String(payload.reasoning_content || '');
-      if (content || thinkingContent) {
+      // 事件 payload 结构: {response: {content, tool_calls, reasoning_details}, ...}
+      const response = (payload.response || {}) as Record<string, unknown>;
+      const content = String(response.content || '');
+      const reasoningDetails = response.reasoning_details;
+      const thinkingContent = extractThinkContentFromReasoningDetails(reasoningDetails);
+      const hasToolCalls = Array.isArray(response.tool_calls) && (response.tool_calls as unknown[]).length > 0;
+      if (content || thinkingContent || hasToolCalls) {
         rebuilt.push({
           id: makeId(),
           role: 'assistant',


### PR DESCRIPTION
## Summary
- OpenAI provider 提取 `message.reasoning_content`（DeepSeek/MiniMax 等模型），转换为 `reasoning_details` 传递给前端
- 前端 `llm_result` handler：当 LLM 返回 tool_calls 时也创建 assistant 消息，避免多个工具调用堆在一起没有思考过程间隔
- `rebuildMessagesFromEvents`（session 重新加载）：修正字段路径从 `payload.content` 改为 `payload.response.content`，修正 `reasoning_content` 为 `reasoning_details` 并使用正确的解析函数

## Test plan
- [ ] 使用 DeepSeek/MiniMax 等模型发送需要工具调用的请求，确认思考过程在工具调用前正确显示
- [ ] 多工具并发调用场景下，确认工具调用之间有 assistant 消息间隔
- [ ] 切换 session 后重新加载，确认历史消息中思考过程正确显示

🤖 Generated with [Claude Code](https://claude.com/claude-code)