### PR TITLE
fix: 修复最后一步 reasoning content 和最终回答重复显示

### DIFF
--- a/agentos/app/web/contexts/ChatSessionContext.tsx
+++ b/agentos/app/web/contexts/ChatSessionContext.tsx
@@ -398,21 +398,29 @@ export function ChatSessionProvider({ children }: { children: React.ReactNode })
       }
       case 'turn_completed': {
         const final = String(payload.final_response || '');
-        if (final) {
-          // 更新最后一条 assistant 消息的内容（不创建新消息）
-          setMessages((prev) => {
-            // 从后往前找最后一条 assistant 消息
-            for (let i = prev.length - 1; i >= 0; i--) {
-              if (prev[i].role === 'assistant') {
+        setMessages((prev) => {
+          // 从后往前找最后一条 assistant 消息
+          for (let i = prev.length - 1; i >= 0; i--) {
+            if (prev[i].role === 'assistant') {
+              const existing = prev[i];
+              // 如果 llm_result 已经设置了相同内容，只折叠思考状态
+              if (existing.content === final || !final) {
                 const next = [...prev];
-                next[i] = { ...next[i], content: final, thinkingState: 'collapsed' };
+                next[i] = { ...next[i], thinkingState: 'collapsed' };
                 return next;
               }
+              // 内容不同时才更新（不创建新消息）
+              const next = [...prev];
+              next[i] = { ...next[i], content: final, thinkingState: 'collapsed' };
+              return next;
             }
-            // 没找到 assistant 消息（理论上不会发生），追加一条
+          }
+          // 没找到 assistant 消息且有内容，追加一条
+          if (final) {
             return [...prev, { id: makeId(), role: 'assistant', content: final, timestamp: Date.now() }];
-          });
-        }
+          }
+          return prev;
+        });
         setIsTyping(false);
         clearInteractions();
         break;

--- a/agentos/app/web/lib/chatTypes.ts
+++ b/agentos/app/web/lib/chatTypes.ts
@@ -201,7 +201,15 @@ export function rebuildMessagesFromEvents(events: Record<string, unknown>[]): Ch
     if (eventType === 'agent.step_completed') {
       const response = String(payload.final_response || '') || String(((payload.result as Record<string, unknown> | undefined)?.content) || '');
       if (response) {
-        rebuilt.push({ id: makeId(), role: 'assistant', content: response, timestamp: Date.now() });
+        // 检查最后一条 assistant 消息是否已有相同内容（由 llm.call_result 创建）
+        const lastAssistant = [...rebuilt].reverse().find(m => m.role === 'assistant');
+        if (lastAssistant && lastAssistant.content === response) {
+          // 内容相同，只折叠思考状态
+          const idx = rebuilt.indexOf(lastAssistant);
+          rebuilt[idx] = { ...rebuilt[idx], thinkingState: rebuilt[idx].thinkingContent ? 'collapsed' : undefined };
+        } else {
+          rebuilt.push({ id: makeId(), role: 'assistant', content: response, timestamp: Date.now() });
+        }
       }
       continue;
     }


### PR DESCRIPTION
## Summary
- `turn_completed` 事件：检查最后一条 assistant 消息的 content 是否和 `final_response` 相同，相同则只折叠思考状态，避免重复显示
- `rebuildMessagesFromEvents`：`agent.step_completed` 检查最后一条 assistant 消息是否已有相同内容（由 `llm.call_result` 创建），避免重复追加

## Root Cause
`llm_result` 事件已经创建了带 content 和 thinkingContent 的 assistant 消息，随后 `turn_completed` / `agent.step_completed` 又用相同的 `final_response` 更新或追加，导致最终回答和思考过程被重复显示。

## Test plan
- [ ] 发送需要工具调用的请求，确认最终回答只显示一次
- [ ] 发送简单问题（无工具调用），确认回答正常显示
- [ ] 切换 session 重新加载历史，确认无重复消息

🤖 Generated with [Claude Code](https://claude.com/claude-code)