### PR TITLE
fix: UI 优化 — 工具调用、思考过程、API Key、session 创建

### DIFF
--- a/agentos/app/web/app/chat/page.tsx
+++ b/agentos/app/web/app/chat/page.tsx
@@ -194,6 +194,7 @@ function ChatContent() {
   const [previewHeight, setPreviewHeight] = useState(350);
   const chatEndRef = useRef<HTMLDivElement>(null);
   const requiredCheckDone = useRef(false);
+  const creatingSessionForAgent = useRef<string | null>(null);
 
   const slideSet = useSlideSet(slidePreviewDir);
 
@@ -310,12 +311,16 @@ function ChatContent() {
   useEffect(() => {
     if (!selectedAgentId || !currentSessionId) return;
     if (currentSessionAgentId === selectedAgentId) return;
+    // 防止异步竞态导致重复创建 session
+    if (creatingSessionForAgent.current === selectedAgentId) return;
 
     if (selectedSessions.length > 0) {
+      creatingSessionForAgent.current = null;
       void switchSession(selectedSessions[0].session_id);
       return;
     }
 
+    creatingSessionForAgent.current = selectedAgentId;
     startNewChat();
     createSession(selectedAgentId);
   }, [
@@ -370,6 +375,7 @@ function ChatContent() {
 
   const handleNewChat = () => {
     if (!selectedAgentId) return;
+    creatingSessionForAgent.current = null;
     startNewChat();
     createSession(selectedAgentId);
   };
@@ -430,6 +436,7 @@ function ChatContent() {
                     hasUnread={false}
                     onClick={() => {
                       cleanupEmptySession();
+                      creatingSessionForAgent.current = null;
                       setSelectedAgentId(agent.id);
                     }}
                   />

--- a/agentos/app/web/app/setup/page.tsx
+++ b/agentos/app/web/app/setup/page.tsx
@@ -37,6 +37,7 @@ export default function SetupPage() {
   const [customProviderName, setCustomProviderName] = useState('');
   const [baseUrl, setBaseUrl] = useState('');
   const [apiKey, setApiKey] = useState('');
+  const [showApiKey, setShowApiKey] = useState(false);
   const [selectedModelKey, setSelectedModelKey] = useState('');
   const [customModelId, setCustomModelId] = useState('');
   const [customModelName, setCustomModelName] = useState('');
@@ -400,15 +401,41 @@ export default function SetupPage() {
                 <label className="block text-sm font-medium text-gray-700">
                   API Key <span className="text-red-500">*</span>
                 </label>
-                <input
-                  type="password"
-                  value={apiKey}
-                  onChange={(e) => setApiKey(e.target.value)}
-                  className="mt-1 block w-full px-3 py-2 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-sm font-mono"
-                  placeholder="sk-..."
-                  autoFocus
-                  autoComplete="off"
-                />
+                <div className="relative mt-1">
+                  <input
+                    type={showApiKey ? "text" : "password"}
+                    value={apiKey}
+                    onChange={(e) => setApiKey(e.target.value)}
+                    className="block w-full px-3 py-2 pr-10 border border-gray-300 rounded-md shadow-sm focus:outline-none focus:ring-blue-500 focus:border-blue-500 text-sm font-mono"
+                    placeholder="sk-..."
+                    autoFocus
+                    autoComplete="off"
+                  />
+                  <button
+                    type="button"
+                    onMouseDown={() => setShowApiKey(true)}
+                    onMouseUp={() => setShowApiKey(false)}
+                    onMouseLeave={() => setShowApiKey(false)}
+                    onTouchStart={() => setShowApiKey(true)}
+                    onTouchEnd={() => setShowApiKey(false)}
+                    className="absolute inset-y-0 right-0 flex items-center px-2.5 text-gray-400 hover:text-gray-600 transition-colors cursor-pointer select-none"
+                    tabIndex={-1}
+                  >
+                    {showApiKey ? (
+                      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M1 12s4-8 11-8 11 8 11 8-4 8-11 8-11-8-11-8z"/>
+                        <circle cx="12" cy="12" r="3"/>
+                      </svg>
+                    ) : (
+                      <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="1.5" strokeLinecap="round" strokeLinejoin="round">
+                        <path d="M17.94 17.94A10.07 10.07 0 0 1 12 20c-7 0-11-8-11-8a18.45 18.45 0 0 1 5.06-5.94"/>
+                        <path d="M9.9 4.24A9.12 9.12 0 0 1 12 4c7 0 11 8 11 8a18.5 18.5 0 0 1-2.16 3.19"/>
+                        <path d="M14.12 14.12a3 3 0 1 1-4.24-4.24"/>
+                        <line x1="1" y1="1" x2="23" y2="23"/>
+                      </svg>
+                    )}
+                  </button>
+                </div>
               </div>
             </div>
 

--- a/agentos/app/web/components/chat/MessageBubble.tsx
+++ b/agentos/app/web/components/chat/MessageBubble.tsx
@@ -95,42 +95,12 @@ function ToolCallItem({ msg }: { msg: ChatMessage }) {
 }
 
 export function ToolCallGroup({ tools }: { tools: ChatMessage[] }) {
-  const [expanded, setExpanded] = useState(false);
-
-  const completed = tools.filter(t => t.toolInfo?.status === 'completed').length;
-  const running = tools.filter(t => t.toolInfo?.status === 'running').length;
-  const total = tools.length;
-  const allDone = running === 0 && total > 0;
-
   return (
-    <div className="my-2 ml-14">
-      <button
-        onClick={() => setExpanded(!expanded)}
-        className="inline-flex items-center gap-2 px-3 py-1.5 rounded-lg bg-muted/50 border border-border/40 text-xs hover:bg-muted/80 transition-colors cursor-pointer select-none"
-      >
-        <ChevronRight size={14} className={`shrink-0 text-muted-foreground transition-transform duration-150 ${expanded ? 'rotate-90' : ''}`} />
-        <Brain size={14} className={allDone ? 'text-primary/60' : 'text-amber-500 animate-pulse'} />
-        <span className="font-medium text-foreground">Thinking</span>
-        <span className="text-muted-foreground">
-          {running > 0 ? `${completed}/${total}` : `${total} 次工具调用`}
-        </span>
-        {running > 0 && (
-          <span className="px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-amber-500/10 text-amber-600 dark:text-amber-400 leading-none">
-            {running} 执行中...
-          </span>
-        )}
-        {allDone && (
-          <span className="px-1.5 py-0.5 rounded-full text-[10px] font-medium bg-green-500/10 text-green-600 dark:text-green-400 leading-none">
-            完成
-          </span>
-        )}
-      </button>
-
-      {expanded && (
-        <div className="ml-3 mt-1 border-l-2 border-border/30 pl-2">
-          {tools.map(tool => <ToolCallItem key={tool.id} msg={tool} />)}
-        </div>
-      )}
+    <div className="flex gap-4 max-w-4xl mx-auto my-2">
+      <div className="w-10 shrink-0" />
+      <div className="flex-1 min-w-0 space-y-1">
+        {tools.map(tool => <ToolCallItem key={tool.id} msg={tool} />)}
+      </div>
     </div>
   );
 }
@@ -192,8 +162,9 @@ export function MessageBubble({ msg }: { msg: ChatMessage }) {
                 onClick={() => setShowThink((prev) => !prev)}
                 className="flex w-full items-center gap-2 px-4 py-3 text-left text-sm font-medium text-amber-900/80 dark:text-amber-200/90"
               >
-                <ChevronDown size={16} className={`shrink-0 transition-transform duration-200 ${showThink ? 'rotate-180' : ''}`} />
+                <Brain size={14} className="shrink-0 text-amber-600 dark:text-amber-400" />
                 <span>思考过程</span>
+                <ChevronDown size={14} className={`shrink-0 transition-transform duration-200 ${showThink ? 'rotate-180' : ''}`} />
               </button>
               <div
                 data-testid="assistant-think-content"


### PR DESCRIPTION
## Summary
- 工具调用移除外层 "Thinking" 折叠框，直接平铺显示，布局与思考过程对齐
- 思考过程折叠按钮前添加 Brain 图标
- Setup 页面 API Key 输入框添加眼睛图标（按住显示，松开隐藏）
- 修复切换 agent 时异步竞态导致重复创建两个空 session 的问题

## Test plan
- [ ] 发送工具调用请求，确认工具调用直接显示（无外层 Thinking 框），与思考过程左对齐
- [ ] 确认思考过程按钮有 Brain 图标
- [ ] Setup 页面按住 API Key 眼睛图标显示明文，松开隐藏
- [ ] 点击切换不同 agent，确认只创建一个新 session

🤖 Generated with [Claude Code](https://claude.com/claude-code)