### PR TITLE
fix: store session artifacts under agent session dirs

### DIFF
--- a/sensenova_claw/kernel/runtime/context_compressor.py
+++ b/sensenova_claw/kernel/runtime/context_compressor.py
@@ -183,8 +183,9 @@ class ContextCompressor:
         """清理会话相关资源（锁），防止内存泄漏。"""
         self._locks.pop(session_id, None)
 
-    def _get_save_dir(self, agent_id: str) -> str:
-        return str(Path(self._sensenova_claw_home) / "agents" / agent_id / "sessions")
+    def _get_save_dir(self, session_id: str, agent_id: str) -> str:
+        from sensenova_claw.platform.config.workspace import resolve_session_artifact_dir
+        return str(resolve_session_artifact_dir(self._sensenova_claw_home, session_id, agent_id=agent_id).parent)
 
     def _cfg(self, key: str, default: Any = None) -> Any:
         return self._config.get(f"context_compression.{key}", default)
@@ -274,7 +275,7 @@ class ContextCompressor:
         # 从前往后处理，跟踪累积偏移量
         new_history = list(history)
         offset = 0
-        save_dir = self._get_save_dir(agent_id)
+        save_dir = self._get_save_dir(session_id, agent_id)
 
         for turn_idx in turns_to_compress:
             turn = turns[turn_idx]
@@ -380,7 +381,7 @@ class ContextCompressor:
 
         # 合并压缩每个 chunk
         new_history: list[dict[str, Any]] = []
-        save_dir = self._get_save_dir(agent_id)
+        save_dir = self._get_save_dir(session_id, agent_id)
 
         for ci, chunk in enumerate(chunks):
             original_msgs = chunk["messages"]

--- a/sensenova_claw/kernel/runtime/workers/tool_worker.py
+++ b/sensenova_claw/kernel/runtime/workers/tool_worker.py
@@ -51,7 +51,7 @@ class ToolSessionWorker(SessionWorker):
         elif event.type == USER_QUESTION_ANSWERED:
             self._resolve_question(event)
 
-    def _truncate_result(self, result: Any, tool_call_id: str) -> Any:
+    def _truncate_result(self, result: Any, tool_call_id: str, agent_id: str | None = None) -> Any:
         """Token 截断：统一控制传给 LLM 的结果长度"""
         result_str = result if isinstance(result, str) else json.dumps(result, ensure_ascii=False)
 
@@ -62,13 +62,15 @@ class ToolSessionWorker(SessionWorker):
             return result
 
         save_dir = config.get("tools.result_truncation.save_dir", "workspace")
-        from sensenova_claw.platform.config.workspace import resolve_sensenova_claw_home
+        from sensenova_claw.platform.config.workspace import (
+            resolve_sensenova_claw_home,
+            resolve_session_artifact_dir,
+        )
         home = resolve_sensenova_claw_home(config)
         if save_dir == "workspace":
-            base_dir = home
+            session_dir = resolve_session_artifact_dir(home, self.session_id, agent_id=agent_id)
         else:
-            base_dir = Path(save_dir)
-        session_dir = base_dir / self.session_id
+            session_dir = resolve_session_artifact_dir(save_dir, self.session_id, agent_id=agent_id)
         session_dir.mkdir(parents=True, exist_ok=True)
 
         file_name = f"tool_result_{tool_call_id[:8]}_{uuid.uuid4().hex[:6]}.txt"
@@ -309,9 +311,8 @@ class ToolSessionWorker(SessionWorker):
         agent_workdir = event.payload.get("_agent_workdir")
         if agent_workdir:
             exec_kwargs["_agent_workdir"] = agent_workdir
-        exec_kwargs["_source_agent_id"] = (
-            str(event.payload.get("_source_agent_id") or event.agent_id or "").strip() or "default"
-        )
+        source_agent_id = str(event.payload.get("_source_agent_id") or event.agent_id or "").strip() or "default"
+        exec_kwargs["_source_agent_id"] = source_agent_id
         if event.turn_id:
             exec_kwargs["_turn_id"] = event.turn_id
         if tool_call_id:
@@ -324,7 +325,7 @@ class ToolSessionWorker(SessionWorker):
                 tool.execute(**exec_kwargs, _session_id=event.session_id),
                 timeout=timeout,
             )
-            result = self._truncate_result(result, tool_call_id)
+            result = self._truncate_result(result, tool_call_id, agent_id=source_agent_id)
         except Exception as exc:  # noqa: BLE001
             success = False
             error = str(exc).strip() or type(exc).__name__

--- a/sensenova_claw/platform/config/workspace.py
+++ b/sensenova_claw/platform/config/workspace.py
@@ -176,6 +176,27 @@ def resolve_agent_workdir(sensenova_claw_home: str, agent_config: Any = None) ->
     return str((Path(sensenova_claw_home).resolve() / "workdir" / agent_id))
 
 
+def resolve_session_artifact_dir(
+    sensenova_claw_home: str | Path,
+    session_id: str,
+    agent_id: str | None = None,
+) -> Path:
+    """解析 session 附件目录。
+
+    统一布局：
+        {sensenova_claw_home}/agents/{agent_id}/sessions/{session_id}/
+
+    这里专门存放与 session 相关的落盘附件，例如：
+    - tool_result_*.txt
+    - compression_phase*.json
+    """
+    home = Path(sensenova_claw_home).expanduser().resolve()
+    safe_agent = str(agent_id or "").strip() or "default"
+    safe_agent = safe_agent.replace("/", "_").replace("\\", "_")
+    safe_session = str(session_id).replace("/", "_").replace("\\", "_")
+    return home / "agents" / safe_agent / "sessions" / safe_session
+
+
 # ---------- 加载 workspace 文件 ----------
 
 async def load_workspace_files(

--- a/tests/unit/test_context_compressor.py
+++ b/tests/unit/test_context_compressor.py
@@ -160,6 +160,37 @@ class TestSaveOriginalMessages:
             assert data["phase"] == 2
             assert "chunk0" in Path(path).name
 
+    @pytest.mark.asyncio
+    async def test_compress_if_needed_saves_under_agent_session_dir(self, tmp_path):
+        """压缩原文应落到 agents/<agent>/sessions/<session_id>/ 下。"""
+        cfg = _make_config({
+            "context_compression.max_context_tokens": 100,
+            "context_compression.phase1_threshold": 0.5,
+            "context_compression.user_input_max_tokens": 5,
+            "context_compression.tool_summary_max_tokens": 10,
+        })
+        provider = _make_llm_provider("压缩后的内容")
+        factory = _make_llm_factory(provider)
+        compressor = ContextCompressor(
+            config=cfg,
+            llm_factory=factory,
+            provider_name="mock",
+            model="mock-v1",
+            sensenova_claw_home=str(tmp_path),
+        )
+        history = [
+            {"role": "user", "content": "A" * 300},
+            {"role": "assistant", "content": "B" * 300},
+            {"role": "user", "content": "latest question"},
+            {"role": "assistant", "content": "latest answer"},
+        ]
+
+        await compressor.compress_if_needed("sess_artifact", history, agent_id="doc-organizer")
+
+        expected_dir = tmp_path / "agents" / "doc-organizer" / "sessions" / "sess_artifact"
+        saved_files = list(expected_dir.glob("compression_phase1_*.json"))
+        assert saved_files
+
 
 # ── ContextCompressor 测试辅助 ──────────────────────────────
 

--- a/tests/unit/test_tool_worker_ask_user.py
+++ b/tests/unit/test_tool_worker_ask_user.py
@@ -1,11 +1,13 @@
 from __future__ import annotations
 
 import asyncio
+from pathlib import Path
 from unittest.mock import AsyncMock, MagicMock
 
 import pytest
 
 import sensenova_claw.kernel.runtime.workers.tool_worker as tool_worker_module
+from sensenova_claw.adapters.storage.repository import Repository
 from sensenova_claw.kernel.events.envelope import EventEnvelope
 from sensenova_claw.kernel.events.types import (
     ERROR_RAISED,
@@ -79,6 +81,46 @@ async def test_ask_user_handler_creates_future(worker, mock_bus):
     task.cancel()
     with pytest.raises(asyncio.CancelledError):
         await task
+
+
+@pytest.mark.asyncio
+async def test_truncate_result_saves_under_agent_session_dir(tmp_path, mock_bus, monkeypatch):
+    """超长工具结果应写到 agents/<agent>/sessions/<session_id>/ 下。"""
+    runtime = MagicMock()
+    runtime.registry = MagicMock()
+    runtime.agent_registry = None
+    runtime.repo = Repository(db_path=str(tmp_path / "test.db"))
+    await runtime.repo.init()
+    monkeypatch.setenv("SENSENOVA_CLAW_HOME", str(tmp_path))
+
+    worker = ToolSessionWorker("agent2agent_abc123", mock_bus, runtime)
+
+    original_get = tool_worker_module.config.get
+    tool_worker_module.config.get = lambda key, default=None: {
+        "tools.result_truncation.max_tokens": 1,
+        "tools.result_truncation.save_dir": "workspace",
+    }.get(key, original_get(key, default))
+    try:
+        result = worker._truncate_result(
+            "x" * 100,
+            "call_fun_123456",
+            agent_id="doc-organizer",
+        )
+    finally:
+        tool_worker_module.config.get = original_get
+
+    expected_dir = (
+        tmp_path
+        / "agents"
+        / "doc-organizer"
+        / "sessions"
+        / "agent2agent_abc123"
+    )
+    saved_files = list(expected_dir.glob("tool_result_call_fun_*.txt"))
+
+    assert saved_files
+    assert saved_files[0].read_text(encoding="utf-8") == "x" * 100
+    assert str(saved_files[0]) in result
 
 
 @pytest.mark.asyncio

--- a/tests/unit/test_workspace_manager.py
+++ b/tests/unit/test_workspace_manager.py
@@ -18,6 +18,7 @@ from sensenova_claw.platform.config.workspace import (
     ensure_workspace,
     load_workspace_files,
     resolve_agent_workdir,
+    resolve_session_artifact_dir,
     resolve_sensenova_claw_home,
 )
 
@@ -258,6 +259,38 @@ def test_resolve_agent_workdir_custom(tmp_path):
     custom = str(tmp_path / "custom_work")
     result = resolve_agent_workdir(str(tmp_path / ".sensenova-claw"), FakeConfig(workdir=custom))
     assert result == str((tmp_path / "custom_work").resolve())
+
+
+def test_resolve_session_artifact_dir_for_agent(tmp_path):
+    """session 附件应落到 agents/<agent>/sessions/<session_id>/ 下。"""
+    result = resolve_session_artifact_dir(
+        str(tmp_path / ".sensenova-claw"),
+        session_id="sess_123",
+        agent_id="doc-organizer",
+    )
+    assert result == (
+        (tmp_path / ".sensenova-claw").resolve()
+        / "agents"
+        / "doc-organizer"
+        / "sessions"
+        / "sess_123"
+    )
+
+
+def test_resolve_session_artifact_dir_defaults_to_default_agent(tmp_path):
+    """未提供 agent_id 时应回退到 default。"""
+    result = resolve_session_artifact_dir(
+        str(tmp_path / ".sensenova-claw"),
+        session_id="sess_456",
+        agent_id="",
+    )
+    assert result == (
+        (tmp_path / ".sensenova-claw").resolve()
+        / "agents"
+        / "default"
+        / "sessions"
+        / "sess_456"
+    )
 
 
 def test_resolve_agent_workdir_no_config():


### PR DESCRIPTION
## Summary
- add a shared session artifact path resolver under agents/<agent_id>/sessions/<session_id>/
- move oversized tool result files into the target agent session artifact directory
- move context compression artifact files into the same agent/session directory and cover the behavior with unit tests

## Test Plan
- UV_CACHE_DIR=/tmp/uv_cache uv run python -m pytest tests/unit/test_workspace_manager.py tests/unit/test_tool_worker_ask_user.py tests/unit/test_context_compressor.py -v
