### PR TITLE
fix: default_model 为 null 时自动选取已配置的模型

### DIFF
--- a/sensenova_claw/platform/config/config.py
+++ b/sensenova_claw/platform/config/config.py
@@ -528,9 +528,23 @@ class Config:
             (provider_name, model_id) 元组
         """
         if not model_key:
-            model_key = self.get("llm.default_model", "mock")
+            model_key = self.get("llm.default_model") or None
 
         models = self.get("llm.models", {})
+
+        # default_model 未设置时，自动选取第一个有有效 api_key 的 model
+        if not model_key:
+            for key, entry in models.items():
+                if not isinstance(entry, dict):
+                    continue
+                provider_name = entry.get("provider", "")
+                provider_cfg = self.get(f"llm.providers.{provider_name}", {})
+                api_key = str(provider_cfg.get("api_key", ""))
+                if api_key and not api_key.startswith("${"):
+                    logger.info("default_model 未设置，自动选用: %s (provider=%s)", key, provider_name)
+                    return provider_name, entry.get("model_id", key)
+            logger.warning("没有找到任何已配置 api_key 的模型，使用 mock provider")
+            return "mock", "mock"
 
         # 精确匹配 models 注册表
         if model_key in models:


### PR DESCRIPTION
## Summary

- **问题**：`llm.default_model` 设为 `null` 时，`resolve_model()` 错误回退到 mock provider，即使用户已通过 secret store 配置了有效的 LLM api_key
- **根因**：`self.get("llm.default_model", "mock")` 在 key 存在但值为 `None` 时返回 `None`，后续逻辑无法匹配任何 model，最终 fallback 到 mock
- **修复**：当 `default_model` 为空/null 时，自动从 `llm.models` 中选取第一个其 provider 有有效 api_key 的模型

## Test plan

- [ ] 配置 `llm.default_model: null`，确认系统自动选取已配置 api_key 的模型
- [ ] 配置 `llm.default_model: claude-sonnet`，确认行为不变
- [ ] 所有 provider 均无 api_key 时，确认仍 fallback 到 mock

🤖 Generated with [Claude Code](https://claude.com/claude-code)