### PR TITLE
Adjust LLM fallback chain

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1135,3 +1135,13 @@ python的运行先conda activate base, 再uv run python xxx.py
 
 失败/风险经验：
 - 当前仓库的 Playwright 默认 `webServer` 仍依赖根目录 `npm run dev`，而这条链路会受 `uv` 缓存权限和 `uv` 自身 panic 影响；前端单用例失败时，必须先区分是页面断言失败还是测试基础设施没起来。
+
+### 2026-03-24 LLM 回退链路补充
+
+成功经验：
+- 当回退策略从“当前模型 -> default -> mock”扩展为“当前模型 -> default -> 任意可用 LLM -> mock”时，最稳的落点是集中改 `llm_worker._fallback_targets()`，不要把“找备用模型”的逻辑分散到 `LLMFactory` 或 `AgentWorker`。
+- “任意可用 LLM”如果不想引入额外配置，直接按 `llm.models` 的定义顺序扫描、结合 provider `api_key` 可用性判断即可，行为可预测，也方便测试锁定。
+- 这类回退改动最适合用 `tests/unit/test_llm_worker.py` 做 TDD：先写“default 失败后应落到第三跳可用模型”的失败用例，再跑整份文件补齐旧断言，能快速识别哪些是新行为，哪些只是历史测试文案过窄。
+
+失败/风险经验：
+- 现有 `MockProvider` 的兜底文案并不包含字符串 `mock`，而是“当前没有可用的 LLM...”；如果测试把“回退到 mock”硬编码成断言回复里必须出现 `mock`，会把文案实现细节误当成行为契约。

--- a/sensenova_claw/kernel/runtime/workers/llm_worker.py
+++ b/sensenova_claw/kernel/runtime/workers/llm_worker.py
@@ -79,14 +79,43 @@ def _format_target(provider_name: str, model: str) -> str:
     return f"{provider_name}:{model}"
 
 
+def _provider_is_available(provider_name: str) -> bool:
+    """判断 provider 当前是否可用。"""
+    if provider_name == "mock":
+        return True
+    provider_cfg = config.get(f"llm.providers.{provider_name}", {})
+    api_key = str(provider_cfg.get("api_key", ""))
+    return bool(api_key) and not api_key.startswith("${")
+
+
+def _first_available_llm_target(
+    excluded_targets: set[tuple[str, str]],
+) -> tuple[str, str] | None:
+    """按 llm.models 配置顺序，返回第一个可用的非 mock 模型。"""
+    models = config.get("llm.models", {})
+    for model_key, entry in models.items():
+        if not isinstance(entry, dict):
+            continue
+        provider_name = str(entry.get("provider", "mock"))
+        if provider_name == "mock" or not _provider_is_available(provider_name):
+            continue
+        target = (provider_name, str(entry.get("model_id", model_key)))
+        if target not in excluded_targets:
+            return target
+    return None
+
+
 def _fallback_targets(provider_name: str, model: str) -> list[tuple[str, str]]:
-    """构造受控回退链路：当前模型 -> default model -> mock。"""
+    """构造受控回退链路：当前模型 -> default model -> 第一个可用 LLM -> mock。"""
     targets: list[tuple[str, str]] = [(provider_name, model)]
     default_target = config.resolve_model(config.get("llm.default_model", "mock"))
     mock_target = config.resolve_model("mock")
 
     if default_target not in targets:
         targets.append(default_target)
+    available_target = _first_available_llm_target(set(targets))
+    if available_target and available_target not in targets:
+        targets.append(available_target)
     if mock_target not in targets:
         targets.append(mock_target)
     return targets

--- a/tests/unit/test_llm_worker.py
+++ b/tests/unit/test_llm_worker.py
@@ -370,7 +370,7 @@ class TestLLMWorkerError:
             assert "qwen:qwen3.5-plus" in notices[0].payload["body"]
             assert "mock:mock-agent-v1" in notices[1].payload["body"]
             fallback = [e for e in collected if e.type == LLM_CALL_RESULT][0]
-            assert "mock" in fallback.payload["response"]["content"].lower()
+            assert "当前没有可用的 LLM" in fallback.payload["response"]["content"]
             assert fallback.payload["finish_reason"] == "stop"
         finally:
             config.data = original
@@ -497,6 +497,57 @@ class TestLLMWorkerError:
         finally:
             config.data = original
 
+    async def test_default_model_failure_falls_back_to_first_available_llm_before_mock(
+        self, private_bus, public_bus
+    ):
+        original = deepcopy(config.data)
+        try:
+            config.data["llm"]["default_model"] = "gemini-pro"
+            config.data["llm"]["models"] = {
+                "mock": {
+                    "provider": "mock",
+                    "model_id": "mock-agent-v1",
+                },
+                "gemini-pro": {
+                    "provider": "gemini",
+                    "model_id": "gemini-2.5-pro",
+                },
+                "gpt-5.4": {
+                    "provider": "openai",
+                    "model_id": "gpt-5.4",
+                },
+            }
+            config.data["llm"]["providers"]["openai"]["api_key"] = "sk-test-openai"
+
+            factory = LLMFactory()
+            factory._providers["qwen"] = _ErrorProvider()
+            factory._providers["gemini"] = _ErrorProvider()
+            openai = _SuccessProvider("third hop success")
+            factory._providers["openai"] = openai
+            runtime = _SimpleLLMRuntime(factory)
+            worker = LLMSessionWorker("s1", private_bus, runtime)
+
+            collected, done, task = await _collect_from_bus(public_bus, 7)
+
+            event = _make_llm_event("qwen", "qwen3.5-plus", [{"role": "user", "content": "test"}])
+            await worker._handle(event)
+            await asyncio.wait_for(done.wait(), timeout=5)
+            task.cancel()
+
+            types = [e.type for e in collected]
+            assert ERROR_RAISED not in types
+            notices = [e for e in collected if e.type == NOTIFICATION_SESSION]
+            assert len(notices) == 4
+            assert "qwen:qwen3.5-plus" in notices[0].payload["body"]
+            assert "gemini:gemini-2.5-pro" in notices[1].payload["body"]
+            assert "gemini:gemini-2.5-pro" in notices[2].payload["body"]
+            assert "openai:gpt-5.4" in notices[3].payload["body"]
+            result = [e for e in collected if e.type == LLM_CALL_RESULT][0]
+            assert result.payload["response"]["content"] == "third hop success"
+            assert openai.calls[0]["model"] == "gpt-5.4"
+        finally:
+            config.data = original
+
     async def test_default_model_failure_falls_back_to_mock_with_notification(self, private_bus, public_bus):
         original = deepcopy(config.data)
         try:
@@ -528,7 +579,7 @@ class TestLLMWorkerError:
             assert "gemini:gemini-2.5-pro" in notices[2].payload["body"]
             assert "mock:mock-agent-v1" in notices[3].payload["body"]
             result = [e for e in collected if e.type == LLM_CALL_RESULT][0]
-            assert "mock" in result.payload["response"]["content"].lower()
+            assert "当前没有可用的 LLM" in result.payload["response"]["content"]
             assert result.payload["finish_reason"] == "stop"
         finally:
             config.data = original


### PR DESCRIPTION
## Summary
- expand the LLM fallback chain to try the current model, `llm.default_model`, then the first available configured LLM before falling back to mock
- add and update llm worker unit tests to cover the new fallback order and stable mock fallback assertions
- record the fallback-chain change in AGENTS notes

## Test Plan
- python3 -m pytest tests/unit/test_llm_worker.py -q