### PR TITLE
fix(coordinator): 移除 send_message 硬超时，实现心跳向上冒泡

### DIFF
--- a/sensenova_claw/capabilities/tools/send_message_tool.py
+++ b/sensenova_claw/capabilities/tools/send_message_tool.py
@@ -289,17 +289,14 @@ class SendMessageTool(Tool):
             )
 
         assert waiter is not None
+        # 超时完全由 coordinator 心跳续期机制控制，
+        # cancel_message → _resolve_waiter_or_publish 会 set_result(payload)，
+        # 所以 await waiter 在超时时返回 {"status": "timed_out", ...}，
+        # 后续第 313 行已有处理。
         try:
-            result_payload = await asyncio.wait_for(waiter, timeout=timeout_seconds + 1)
-        except asyncio.TimeoutError:
-            await self._coordinator.cancel_message(
-                record_id=record_id,
-                reason=f"{target_id} 在 {timeout_seconds} 秒内未完成处理。",
-                status="timed_out",
-                propagate_to_child=True,
-                source_session_id=current_session_id or None,
-            )
-            return f"发送失败：{target_id} 在 {timeout_seconds} 秒内未完成处理。"
+            result_payload = await waiter
+        except asyncio.CancelledError:
+            return f"发送失败：{target_id} 的委托会话被清理。"
 
         if result_payload.get("status") == "completed":
             next_session_id = str(result_payload.get("child_session_id", ""))

--- a/sensenova_claw/kernel/runtime/agent_message_coordinator.py
+++ b/sensenova_claw/kernel/runtime/agent_message_coordinator.py
@@ -60,6 +60,7 @@ class AgentMessageCoordinator:
         self._timeout_tasks: dict[str, asyncio.Task] = {}
         self._retry_tasks: dict[str, asyncio.Task] = {}
         self._last_heartbeat: dict[str, float] = {}
+        self._record_parent_session: dict[str, str] = {}  # record_id → parent_session_id
 
     async def start(self) -> None:
         self._agent_runtime.bus_router.on_destroy(self._on_session_destroy)
@@ -151,21 +152,31 @@ class AgentMessageCoordinator:
     async def _event_loop(self) -> None:
         async for event in self._bus.subscribe():
             try:
-                if event.type == AGENT_MESSAGE_REQUESTED:
-                    await self._handle_message_requested(event)
-                elif event.type == AGENT_STEP_COMPLETED:
-                    await self._handle_child_completed(event)
-                elif event.type == ERROR_RAISED:
-                    await self._handle_child_failed(event)
-                elif event.type == USER_TURN_CANCEL_REQUESTED:
-                    await self._handle_cancel_requested(event)
-                # 心跳续期（独立 if，不与上面 elif 冲突）
-                if event.type in self.HEARTBEAT_TYPES:
-                    record_id = self._child_session_index.get(event.session_id)
-                    if record_id and record_id in self._last_heartbeat:
-                        self._last_heartbeat[record_id] = time.time()
+                await self._dispatch_event(event)
             except Exception:  # noqa: BLE001
                 logger.exception("AgentMessageCoordinator 处理事件失败")
+
+    async def _dispatch_event(self, event: EventEnvelope) -> None:
+        if event.type == AGENT_MESSAGE_REQUESTED:
+            await self._handle_message_requested(event)
+        elif event.type == AGENT_STEP_COMPLETED:
+            await self._handle_child_completed(event)
+        elif event.type == ERROR_RAISED:
+            await self._handle_child_failed(event)
+        elif event.type == USER_TURN_CANCEL_REQUESTED:
+            await self._handle_cancel_requested(event)
+        # 心跳续期（独立 if，不与上面 elif 冲突）
+        if event.type in self.HEARTBEAT_TYPES:
+            self._renew_heartbeat_chain(event.session_id)
+
+    def _renew_heartbeat_chain(self, session_id: str) -> None:
+        """续期 session_id 对应的 record 及所有祖先 record 的心跳。"""
+        record_id = self._child_session_index.get(session_id)
+        now = time.time()
+        while record_id and record_id in self._last_heartbeat:
+            self._last_heartbeat[record_id] = now
+            parent_sid = self._record_parent_session.get(record_id, "")
+            record_id = self._child_session_index.get(parent_sid) if parent_sid else None
 
     async def _handle_message_requested(self, event: EventEnvelope) -> None:
         payload = event.payload
@@ -213,6 +224,8 @@ class AgentMessageCoordinator:
             timeout_seconds=timeout_seconds,
         )
         self._child_session_index[child_session_id] = record_id
+        if parent_session_id:
+            self._record_parent_session[record_id] = parent_session_id
         await self._repo.save_message_record(record)
 
         if mode == "async" and parent_session_id:
@@ -467,6 +480,7 @@ class AgentMessageCoordinator:
         record_id = self._child_session_index.pop(session_id, None)
         if not record_id:
             return
+        self._record_parent_session.pop(record_id, None)
         self._cancel_record_tasks(record_id)
         future = self._sync_waiters.pop(record_id, None)
         if future and not future.done():

--- a/tests/unit/test_agent_message_coordinator.py
+++ b/tests/unit/test_agent_message_coordinator.py
@@ -520,3 +520,160 @@ class TestAgentMessageCoordinator:
         payload = await asyncio.wait_for(waiter, timeout=5)
         assert payload["status"] == "timed_out"
         await coordinator.stop()
+
+    async def test_heartbeat_bubbles_up_to_ancestor(self, test_repo):
+        """多层委托 A→B→C 时，C 的心跳应续期 B→C 和 A→B 两条 record"""
+        bus = PublicEventBus()
+        runtime = _FakeAgentRuntime()
+        coordinator = AgentMessageCoordinator(
+            bus=bus, repo=test_repo, agent_runtime=runtime,
+        )
+
+        # 第一层：A→B（record_ab, parent=session_A, child=session_B）
+        await coordinator._handle_message_requested(EventEnvelope(
+            type=AGENT_MESSAGE_REQUESTED,
+            session_id="session_A",
+            trace_id="record_ab",
+            payload={
+                "record_id": "record_ab",
+                "target_id": "agent_B",
+                "message": "A→B",
+                "mode": "sync",
+                "depth": 1,
+                "send_chain": ["A"],
+                "parent_session_id": "session_A",
+                "timeout_seconds": 0.5,
+                "max_retries": 0,
+            },
+        ))
+        record_ab = await test_repo.get_message_record("record_ab")
+        child_b_sid = record_ab.child_session_id
+
+        # 第二层：B→C（record_bc, parent=session_B(=child_b_sid), child=session_C）
+        await coordinator._handle_message_requested(EventEnvelope(
+            type=AGENT_MESSAGE_REQUESTED,
+            session_id=child_b_sid,
+            trace_id="record_bc",
+            payload={
+                "record_id": "record_bc",
+                "target_id": "agent_C",
+                "message": "B→C",
+                "mode": "sync",
+                "depth": 2,
+                "send_chain": ["A", "B"],
+                "parent_session_id": child_b_sid,
+                "timeout_seconds": 0.5,
+                "max_retries": 0,
+            },
+        ))
+        record_bc = await test_repo.get_message_record("record_bc")
+        child_c_sid = record_bc.child_session_id
+
+        # 验证索引已建立
+        assert coordinator._record_parent_session["record_ab"] == "session_A"
+        assert coordinator._record_parent_session["record_bc"] == child_b_sid
+        assert coordinator._child_session_index[child_b_sid] == "record_ab"
+        assert coordinator._child_session_index[child_c_sid] == "record_bc"
+
+        import time
+        # 记录初始心跳时间
+        initial_ab = coordinator._last_heartbeat["record_ab"]
+        initial_bc = coordinator._last_heartbeat["record_bc"]
+
+        await asyncio.sleep(0.05)
+
+        # C 发出心跳 → 应同时续期 record_bc 和 record_ab
+        coordinator._renew_heartbeat_chain(child_c_sid)
+
+        assert coordinator._last_heartbeat["record_bc"] > initial_bc
+        assert coordinator._last_heartbeat["record_ab"] > initial_ab
+        # 两者应该被设为相同的 now
+        assert coordinator._last_heartbeat["record_ab"] == coordinator._last_heartbeat["record_bc"]
+
+        await coordinator.stop()
+
+    async def test_heartbeat_bubble_prevents_ancestor_timeout(self, test_repo):
+        """多层委托中，子 agent 活动应阻止祖父级超时"""
+        bus = PublicEventBus()
+        runtime = _FakeAgentRuntime()
+        coordinator = AgentMessageCoordinator(
+            bus=bus, repo=test_repo, agent_runtime=runtime,
+        )
+        await coordinator.start()
+        await asyncio.sleep(0)
+
+        waiter_ab = coordinator.register_sync_waiter("record_ab2")
+
+        # A→B（timeout=1s，给心跳冒泡留充足余量）
+        await bus.publish(EventEnvelope(
+            type=AGENT_MESSAGE_REQUESTED,
+            session_id="session_A2",
+            trace_id="record_ab2",
+            payload={
+                "record_id": "record_ab2",
+                "target_id": "agent_B",
+                "message": "A→B",
+                "mode": "sync",
+                "depth": 1,
+                "send_chain": ["A"],
+                "parent_session_id": "session_A2",
+                "timeout_seconds": 1.0,
+                "max_retries": 0,
+            },
+        ))
+        await asyncio.sleep(0.1)
+        record_ab = await test_repo.get_message_record("record_ab2")
+        child_b_sid = record_ab.child_session_id
+
+        # B→C
+        await bus.publish(EventEnvelope(
+            type=AGENT_MESSAGE_REQUESTED,
+            session_id=child_b_sid,
+            trace_id="record_bc2",
+            payload={
+                "record_id": "record_bc2",
+                "target_id": "agent_C",
+                "message": "B→C",
+                "mode": "sync",
+                "depth": 2,
+                "send_chain": ["A", "B"],
+                "parent_session_id": child_b_sid,
+                "timeout_seconds": 1.0,
+                "max_retries": 0,
+            },
+        ))
+        await asyncio.sleep(0.1)
+        record_bc = await test_repo.get_message_record("record_bc2")
+        child_c_sid = record_bc.child_session_id
+
+        # C 持续发心跳，总时长 > timeout（1s），每次间隔 < timeout/3
+        for _ in range(6):
+            await asyncio.sleep(0.2)
+            await bus.publish(EventEnvelope(
+                type=TOOL_CALL_COMPLETED,
+                session_id=child_c_sid,
+                payload={},
+            ))
+            await asyncio.sleep(0.02)  # 让 coordinator 处理事件
+
+        # A→B 不应超时（因为 C 的心跳冒泡续期了 record_ab2）
+        record_ab = await test_repo.get_message_record("record_ab2")
+        assert record_ab.status == "running", f"Expected running but got {record_ab.status}"
+
+        # 手动完成 B→C 和 A→B
+        await bus.publish(EventEnvelope(
+            type=AGENT_STEP_COMPLETED,
+            session_id=child_c_sid,
+            turn_id=record_bc.active_turn_id,
+            payload={"result": {"content": "C done"}},
+        ))
+        await asyncio.sleep(0.1)
+        await bus.publish(EventEnvelope(
+            type=AGENT_STEP_COMPLETED,
+            session_id=child_b_sid,
+            turn_id=record_ab.active_turn_id,
+            payload={"result": {"content": "B done"}},
+        ))
+        payload = await asyncio.wait_for(waiter_ab, timeout=5)
+        assert payload["status"] == "completed"
+        await coordinator.stop()


### PR DESCRIPTION
## 问题

      1. `send_message_tool` 的 `asyncio.wait_for(waiter, timeout=301s)` 硬超时覆盖了 coordinator 的心跳续期机制
      2. 多层委托（A→B→C）时，C 的活动只续期 B→C 的心跳，不会续期 A→B，导致 A→B 超时

      ## 修改

      - **移除 send_message_tool 硬超时**：`await asyncio.wait_for(waiter, timeout)` → `await waiter`，超时完全由 coordinator 心跳机制控制
      - **心跳向上冒泡**：新增 `_record_parent_session` 索引（record_id → parent_session_id），心跳续期时沿委托链向上遍历，续期所有祖先 record
      - **重构**：提取 `_dispatch_event` 和 `_renew_heartbeat_chain` 方法，提升可测试性

      ## 冒泡链路示例（A→B→C）

      ```
      event.session_id = C
      → _child_session_index[C] = record_BC → 续期
      → _record_parent_session[record_BC] = B
      → _child_session_index[B] = record_AB → 续期
      → _record_parent_session[record_AB] = A
      → _child_session_index[A] = None → 停止
      ```

      ## 测试

      - 新增 `test_heartbeat_bubbles_up_to_ancestor`：验证冒泡索引正确性
      - 新增 `test_heartbeat_bubble_prevents_ancestor_timeout`：验证多层委托中子 agent 活动阻止祖父级超时
      - 全部 11 个 coordinator 单测通过