### PR TITLE
fix: 修复 NotificationDropdown 无限渲染循环

### DIFF
--- a/sensenova_claw/app/web/components/notification/NotificationDropdown.tsx
+++ b/sensenova_claw/app/web/components/notification/NotificationDropdown.tsx
@@ -423,13 +423,18 @@ export function NotificationDropdown() {
     }
   }, [cards, wsSend, markCardPending, resolveCard, handleNavigate, resolveInteractionFromNotification]);
 
+  // 用 ref 持有最新 handleResolve，避免 useEffect 因 handleResolve 变化反复调用
+  // setOnActionToastAction 导致无限循环
+  const handleResolveRef = useRef(handleResolve);
+  handleResolveRef.current = handleResolve;
+
   // 注册操作弹窗的回调，使弹窗按钮也能发送 WebSocket 响应
   useEffect(() => {
     setOnActionToastAction((cardId: string, actionValue: string, inputValue?: string) => {
-      handleResolve(cardId, actionValue, inputValue);
+      handleResolveRef.current(cardId, actionValue, inputValue);
     });
     return () => setOnActionToastAction(null);
-  }, [handleResolve, setOnActionToastAction]);
+  }, [setOnActionToastAction]);
 
   // 按类型分组
   const pendingCards = cards.filter(c => !c.resolved);


### PR DESCRIPTION
## Summary
- `handleResolve` 依赖 `cards`，每次 cards 变化都会重建
- `useEffect` 依赖 `handleResolve`，重建后反复调用 `setOnActionToastAction`
- `setOnActionToastAction` 更新 Provider state → 子组件重渲染 → 无限循环
- 改用 `useRef` 持有最新 `handleResolve`，`useEffect` 仅依赖稳定的 `setOnActionToastAction`

## Test plan
- [ ] 打开任意页面，确认控制台无 "Maximum update depth exceeded" 警告
- [ ] 点击导航按钮正常跳转
- [ ] 通知面板操作按钮（审批/回答）功能正常

🤖 Generated with [Claude Code](https://claude.com/claude-code)