### PR TITLE
fix: auto dismiss idle action toasts

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1257,3 +1257,13 @@ python的运行先conda activate base, 再uv run python xxx.py
 
 失败/风险经验：
 - 进程内 e2e 若依赖“当前默认模型”为 mock，很容易被本机 `config.yml` 漂移污染；更稳的做法是显式注册一个 `model=\"mock\"` 的 default agent，而不是只改全局 `llm.default_model`。
+
+### 2026-03-25 Action Toast 自动消失补充
+
+成功经验：
+- `action-toast` 这类浮层和通知中心卡片是两套状态，需求若只是“界面上自动收口”，最稳的落点是 `NotificationProvider` 里只移除 `actionToasts`，不要顺手改 `cards/resolved/pending`，否则很容易把“未处理”误判成“已处理”。
+- Playwright 1.52 已支持 `page.clock.install()` 和 `page.clock.fastForward()`；对 60 秒/15 秒这类前端定时器需求，优先用 mock clock 写回归，能把慢测压到秒级且更稳定。
+- `pending` 状态的 toast 不应继续保留旧定时器；在用户点击动作时先清掉 timer，再切 `pending`，可以避免“已提交但浮层被旧 timer 误删”的竞态。
+
+失败/风险经验：
+- `sensenova_claw/app/web/e2e/tool-confirmation-resolution.spec.ts` 里的 session 弹窗用例当前在本机仍会失败，现象是 `/sessions/[id]` 路径下拿不到 `tool-confirmation-dialog`；这和本次 toast 自动消失改动无直接证据关联，提交前需明确区分“本次新增回归通过”与“仓库既有用例仍失败”。

--- a/docs/superpowers/plans/2026-03-25-action-toast-auto-dismiss.md
+++ b/docs/superpowers/plans/2026-03-25-action-toast-auto-dismiss.md
@@ -1,0 +1,76 @@
+# Action Toast 自动消失 Implementation Plan
+
+> **For agentic workers:** REQUIRED: Use superpowers:subagent-driven-development (if subagents available) or superpowers:executing-plans to implement this plan. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** 让待用户处理的 `action-toast` 在 60 秒后自动从界面消失，同时保留通知中心卡片与既有 resolved 收口逻辑。
+
+**Architecture:** 在 `NotificationProvider` 中集中管理 `actionToasts` 的 60 秒超时回收，只移除浮层，不修改通知卡片状态。现有 `pending` 和 `resolved` 流程保持不变，避免引入新的交互歧义。
+
+**Tech Stack:** Next.js 14、React、TypeScript、Playwright
+
+---
+
+## Chunk 1: 回归测试先行
+
+### Task 1: 为 action-toast 自动消失补一个失败用例
+
+**Files:**
+- Modify: `sensenova_claw/app/web/e2e/tool-confirmation-resolution.spec.ts`
+
+- [ ] **Step 1: 写失败测试**
+
+在 `tool-confirmation-resolution.spec.ts` 中新增一个用例：
+- 发送 `tool_confirmation_requested`
+- 断言 `action-toast` 出现
+- 快进 60 秒
+- 断言 `action-toast` 消失
+- 断言通知中心卡片依然存在
+
+- [ ] **Step 2: 运行该测试并确认失败**
+
+Run: `cd sensenova_claw/app/web && PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright test e2e/tool-confirmation-resolution.spec.ts --grep "60 秒后自动消失"`
+
+Expected: FAIL，当前 toast 不会自动消失。
+
+## Chunk 2: 最小实现
+
+### Task 2: 在 NotificationProvider 中增加 toast 生命周期管理
+
+**Files:**
+- Modify: `sensenova_claw/app/web/components/notification/NotificationProvider.tsx`
+
+- [ ] **Step 3: 写最小实现**
+
+实现要点：
+- 增加 `ACTION_TOAST_AUTO_DISMISS_MS = 60_000`
+- 为未 `pending` 的 toast 注册剩余时间定时器
+- 定时器到点后只移除对应 toast
+- effect cleanup 中清理 timer，避免重复注册
+
+- [ ] **Step 4: 运行测试并确认通过**
+
+Run: `cd sensenova_claw/app/web && PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright test e2e/tool-confirmation-resolution.spec.ts --grep "60 秒后自动消失"`
+
+Expected: PASS
+
+## Chunk 3: 回归验证与提交
+
+### Task 3: 跑相关回归并提交
+
+**Files:**
+- Modify: `docs/superpowers/specs/2026-03-25-action-toast-auto-dismiss-design.md`
+- Modify: `docs/superpowers/plans/2026-03-25-action-toast-auto-dismiss.md`
+
+- [ ] **Step 5: 跑相关前端回归**
+
+Run: `cd sensenova_claw/app/web && PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright test e2e/tool-confirmation-resolution.spec.ts`
+
+Expected: PASS
+
+- [ ] **Step 6: 提交改动**
+
+```bash
+git add -f docs/superpowers/specs/2026-03-25-action-toast-auto-dismiss-design.md docs/superpowers/plans/2026-03-25-action-toast-auto-dismiss.md
+git add sensenova_claw/app/web/components/notification/NotificationProvider.tsx sensenova_claw/app/web/e2e/tool-confirmation-resolution.spec.ts
+git commit -m "fix: auto dismiss idle action toasts"
+```

--- a/docs/superpowers/specs/2026-03-25-action-toast-auto-dismiss-design.md
+++ b/docs/superpowers/specs/2026-03-25-action-toast-auto-dismiss-design.md
@@ -1,0 +1,51 @@
+# Action Toast 自动消失设计
+
+## 背景
+
+当前 `action-toast` 用于承载 `tool_confirmation`、`user_question` 等需要用户关注的提示。现状是这类 toast 只支持手动关闭或等待服务端 `resolved` 事件收口，没有任何超时回收逻辑，因此会长期停留在页面右上角，影响后续交互。
+
+## 目标
+
+- 待用户处理的 `action-toast` 在显示 60 秒后自动从界面消失。
+- 自动消失仅影响右上角浮层，不影响通知中心中的持久化卡片。
+- 已进入 `pending` 的 toast 不走自动消失逻辑，仍等待服务端最终结果。
+- 已收到 `resolved` 的 toast 继续按现有逻辑立即关闭。
+
+## 方案
+
+### 方案一：在 `NotificationProvider` 统一管理 toast 生命周期
+
+在 provider 中为 `actionToasts` 增加超时清理逻辑，按 `createdAtMs` 计算剩余时间，仅对“未 `pending` 且未 `resolved` 的浮层”注册 60 秒定时器。定时器触发时仅移除对应 toast，不修改通知卡片状态。
+
+优点：
+
+- 生命周期集中管理，和 `pushCard` / `markCardPending` / `resolveCard` 的状态流保持一致。
+- 不依赖单个 `ActionToastItem` 的挂载时机，避免列表补位或重渲染导致重复计时。
+- 更容易在 provider 层做统一清理，减少内存泄漏风险。
+
+缺点：
+
+- 需要在 provider 中增加一段 effect 和 timer 管理代码。
+
+### 方案二：在 `ActionToastItem` 中逐项计时
+
+每个 toast 组件挂载时启动 60 秒定时器，到点后调用 `onDismiss`。
+
+优点：
+
+- 改动表面上更局部。
+
+缺点：
+
+- toast 列表裁剪、重排或重新挂载时容易重复创建定时器。
+- 行为更依赖渲染细节，不利于后续维护。
+
+## 结论
+
+采用方案一，在 `NotificationProvider` 统一处理超时回收。
+
+## 测试策略
+
+- 增加前端回归测试，覆盖“toast 出现后 60 秒自动消失”的行为。
+- 断言通知卡片仍然保留，说明只是浮层收口，不是把交互直接判定为完成。
+- 保留现有 `resolved` 收口测试，确保新的超时逻辑不影响已有行为。

--- a/sensenova_claw/app/web/components/notification/NotificationProvider.tsx
+++ b/sensenova_claw/app/web/components/notification/NotificationProvider.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { createContext, useCallback, useEffect, useState } from 'react';
+import { createContext, useCallback, useEffect, useRef, useState } from 'react';
 
 import {
   NotificationToast,
@@ -87,6 +87,7 @@ function makeNotificationId() {
 }
 
 const MAX_CARDS = 50;
+const ACTION_TOAST_AUTO_DISMISS_MS = 60_000;
 
 export function NotificationProvider({ children }: { children: React.ReactNode }) {
   const [notifications, setNotifications] = useState<ToastNotification[]>([]);
@@ -95,10 +96,23 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
   const [permission, setPermission] = useState<NotificationPermission | 'unsupported'>('unsupported');
   // 操作回调：由 NotificationDropdown 注册，处理 WebSocket 响应
   const [onActionToastAction, setOnActionToastActionRaw] = useState<((cardId: string, actionValue: string, inputValue?: string) => void) | null>(null);
+  const actionToastTimeoutsRef = useRef<Map<string, number>>(new Map());
 
   const setOnActionToastAction = useCallback((fn: ((cardId: string, actionValue: string, inputValue?: string) => void) | null) => {
     setOnActionToastActionRaw(() => fn);
   }, []);
+
+  const clearActionToastTimer = useCallback((toastId: string) => {
+    const timerId = actionToastTimeoutsRef.current.get(toastId);
+    if (timerId === undefined) return;
+    window.clearTimeout(timerId);
+    actionToastTimeoutsRef.current.delete(toastId);
+  }, []);
+
+  const removeActionToast = useCallback((toastId: string) => {
+    clearActionToastTimer(toastId);
+    setActionToasts(prev => prev.filter(t => t.id !== toastId));
+  }, [clearActionToastTimer]);
 
   useEffect(() => {
     if (typeof window === 'undefined' || !('Notification' in window)) {
@@ -106,6 +120,43 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
       return;
     }
     setPermission(window.Notification.permission);
+  }, []);
+
+  useEffect(() => {
+    const visibleToastIds = new Set(actionToasts.map(toast => toast.id));
+    for (const toastId of actionToastTimeoutsRef.current.keys()) {
+      const toast = actionToasts.find(item => item.id === toastId);
+      if (!toast || toast.pending) {
+        clearActionToastTimer(toastId);
+      }
+    }
+
+    actionToasts.forEach((toast) => {
+      if (toast.pending || actionToastTimeoutsRef.current.has(toast.id)) {
+        return;
+      }
+      const remainingMs = Math.max(0, toast.createdAtMs + ACTION_TOAST_AUTO_DISMISS_MS - Date.now());
+      const timerId = window.setTimeout(() => {
+        actionToastTimeoutsRef.current.delete(toast.id);
+        setActionToasts(prev => prev.filter(t => t.id !== toast.id));
+      }, remainingMs);
+      actionToastTimeoutsRef.current.set(toast.id, timerId);
+    });
+
+    for (const toastId of actionToastTimeoutsRef.current.keys()) {
+      if (!visibleToastIds.has(toastId)) {
+        clearActionToastTimer(toastId);
+      }
+    }
+  }, [actionToasts, clearActionToastTimer]);
+
+  useEffect(() => {
+    return () => {
+      for (const timerId of actionToastTimeoutsRef.current.values()) {
+        window.clearTimeout(timerId);
+      }
+      actionToastTimeoutsRef.current.clear();
+    };
   }, []);
 
   const dismissNotification = (id: string) => {
@@ -248,13 +299,21 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
         : c
     ));
     // 同时移除对应的操作弹窗
-    setActionToasts(prev => prev.filter(t => t.cardId !== id));
-  }, []);
+    setActionToasts(prev => {
+      const matchedToasts = prev.filter(t => t.cardId === id);
+      matchedToasts.forEach((toast) => clearActionToastTimer(toast.id));
+      return prev.filter(t => t.cardId !== id);
+    });
+  }, [clearActionToastTimer]);
 
   const dismissCard = useCallback((id: string) => {
     setCards(prev => prev.filter(c => c.id !== id));
-    setActionToasts(prev => prev.filter(t => t.cardId !== id));
-  }, []);
+    setActionToasts(prev => {
+      const matchedToasts = prev.filter(t => t.cardId === id);
+      matchedToasts.forEach((toast) => clearActionToastTimer(toast.id));
+      return prev.filter(t => t.cardId !== id);
+    });
+  }, [clearActionToastTimer]);
 
   const clearAllCards = useCallback(() => {
     setCards([]);
@@ -263,6 +322,7 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
 
   // 操作弹窗：用户点击按钮
   const handleActionToastAction = useCallback((toastId: string, cardId: string, actionValue: string, inputValue?: string) => {
+    clearActionToastTimer(toastId);
     setActionToasts(prev => prev.map(t =>
       t.id === toastId
         ? { ...t, pending: true, pendingAction: actionValue }
@@ -271,12 +331,12 @@ export function NotificationProvider({ children }: { children: React.ReactNode }
     markCardPending(cardId, actionValue);
     // 触发回调（发送 WebSocket 响应）
     onActionToastAction?.(cardId, actionValue, inputValue);
-  }, [markCardPending, onActionToastAction]);
+  }, [clearActionToastTimer, markCardPending, onActionToastAction]);
 
   // 操作弹窗：用户关闭（不操作）
   const handleActionToastDismiss = useCallback((toastId: string) => {
-    setActionToasts(prev => prev.filter(t => t.id !== toastId));
-  }, []);
+    removeActionToast(toastId);
+  }, [removeActionToast]);
 
   const unreadCount = cards.filter(c => !c.read && !c.resolved).length;
 

--- a/sensenova_claw/app/web/e2e/tool-confirmation-resolution.spec.ts
+++ b/sensenova_claw/app/web/e2e/tool-confirmation-resolution.spec.ts
@@ -222,6 +222,41 @@ test('chat 页面审批通知应等待 tool_confirmation_resolved 后才收口',
   await expect(toast).not.toBeVisible({ timeout: 10000 });
 });
 
+test('chat 页面待处理 action-toast 应在 60 秒后自动消失但保留通知卡片', async ({ page }) => {
+  await page.clock.install({ time: new Date('2026-03-25T10:00:00Z') });
+  await page.goto('/chat?token=e2e-sensenova-claw-token');
+
+  await page.evaluate(() => {
+    (window as any).__mockWs.emit({
+      type: 'tool_confirmation_requested',
+      session_id: 'sess_confirm_idle',
+      payload: {
+        tool_call_id: 'tc_confirm_idle',
+        tool_name: 'bash_command',
+        risk_level: 'high',
+        arguments: { command: 'rm -rf /tmp/demo' },
+        timeout: 60,
+        timeout_action: 'approve',
+        requested_at_ms: Date.now(),
+      },
+      timestamp: Date.now() / 1000,
+    });
+  });
+
+  const toast = page.getByTestId('action-toast').filter({ hasText: '需要授权' });
+  await expect(toast).toBeVisible({ timeout: 10000 });
+
+  await page.clock.fastForward('00:59');
+  await expect(toast).toBeVisible();
+
+  await page.clock.fastForward('00:01');
+  await expect(toast).not.toBeVisible({ timeout: 10000 });
+
+  await page.locator('button[title*="通知"]').click();
+  await expect(page.getByText('通知中心')).toBeVisible();
+  await expect(page.getByText('工具 "bash_command" 需要你的确认才能执行')).toBeVisible();
+});
+
 test('session 页面确认弹窗超时后应等待 resolved 事件再关闭', async ({ page }) => {
   await page.goto('/sessions/sess_e2e');
 


### PR DESCRIPTION
## 概要
- 为待用户处理的 `action-toast` 增加 60 秒自动消失逻辑
- 自动消失只收口右上角浮层，通知中心卡片仍保留，用户仍可继续处理
- 补充 Playwright 回归用例，并记录本次任务经验到 `AGENTS.md`

## 验证
- `cd sensenova_claw/app/web && PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright test e2e/tool-confirmation-resolution.spec.ts --grep "60 秒后自动消失"`
  - 通过
- `cd sensenova_claw/app/web && PLAYWRIGHT_BROWSERS_PATH=/tmp/pw-browsers npx playwright test e2e/tool-confirmation-resolution.spec.ts`
  - 其中 2 个 chat 场景通过
  - 现有 `session 页面确认弹窗超时后应等待 resolved 事件再关闭` 用例仍失败，现象为 `/sessions/[id]` 下未出现 `tool-confirmation-dialog`；本次改动未直接触及该路径
