### PR TITLE
feat: unify llm sampling defaults

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1258,6 +1258,16 @@ python的运行先conda activate base, 再uv run python xxx.py
 失败/风险经验：
 - 进程内 e2e 若依赖“当前默认模型”为 mock，很容易被本机 `config.yml` 漂移污染；更稳的做法是显式注册一个 `model=\"mock\"` 的 default agent，而不是只改全局 `llm.default_model`。
 
+### 2026-03-26 LLM 默认采样参数补充
+
+成功经验：
+- 这类“默认参数统一”问题不要只改 `DEFAULT_CONFIG`；最稳的做法是同时检查 `AgentConfig` 默认值、`AgentRegistry` fallback、`AgentSessionWorker` 合并链路、`LLMSessionWorker` 兜底链路，以及绕过主链路的直接 `provider.call()` 特例，否则很容易出现“普通聊天已更新，但标题生成/摘要仍是旧值”的半收敛状态。
+- `top_p/top_k` 这类额外采样参数放在 `agent.extra_body` 做全局默认，再在 worker/provider 里统一 merge，比为每个 provider 单独加新的函数参数更省改动，也更兼容现有 `extra_body` 透传设计。
+- 对带默认值的运行时链路，最划算的红测是“Config 默认值 + AgentConfig 默认值 + Worker 最终传给 provider 的参数”三层；这样能快速区分“配置没改”“对象默认没改”“链路没透传”。
+
+失败/风险经验：
+- 当前仓库的 `tests/unit/test_llm_worker.py` 本身存在一批与本次改动无关的既有失败，主要围绕流式事件顺序和 fallback 预期；验证这类默认值改动时，应单独抽出新增/相关用例运行，避免把历史问题误判成本次回归。
+
 ### 2026-03-25 Action Toast 自动消失补充
 
 成功经验：

--- a/config_example.yml
+++ b/config_example.yml
@@ -2,7 +2,6 @@
 # 复制此文件为 config.yml 并填入真实的 API Key
 
 system:
-  workspace_dir: ~/.sensenova-claw/workspace
   database_path: ~/.sensenova-claw/db/sensenova-claw.db
 
 security:
@@ -167,8 +166,7 @@ agents:
   default:
     name: Default Agent
     description: 默认 AI Agent
-    model: gemini_maas_pro_20260219
-    temperature: 0.2
+    temperature: 1.0
     tools: []
     skills: []
     can_send_message_to: []
@@ -176,11 +174,20 @@ agents:
     max_pingpong_turns: 10
     enabled: true
 
+  system-admin:
+    name: 系统运维管理员
+    description: 系统运维管理员，负责 Sensenova-Claw 平台的配置管理、Agent 管理、工具管理、Skill/Plugin 安装等运维操作
+    temperature: 1.0
+    tools: ["read_file", "write_file", "bash_command"]
+    skills: ["system-admin-skill"]
+    max_send_depth: 2
+    max_pingpong_turns: 10
+    enabled: true
+
   proactive-agent:
     name: Proactive Agent
     description: 自主执行定时任务和信息推送的 agent
-    model: gemini_maas_pro_20260219
-    temperature: 0.2
+    temperature: 1.0
     tools: ["send_message", "fetch_url", "read_file", "write_file", "bash_command", "serper_search", "memory_search", "list_proactive_jobs", "create_proactive_job", "manage_proactive_job"]
     skills: []
     max_send_depth: 2
@@ -190,8 +197,7 @@ agents:
   office-main:
     name: 办公主助手
     description: 办公任务总调度，负责理解需求并委托给专业 agent
-    model: gemini_maas_pro_20260219
-    temperature: 0.2
+    temperature: 1.0
     tools: []
     skills: []
     max_send_depth: 3
@@ -200,8 +206,7 @@ agents:
   ppt-agent:
     name: PPT 生成助手
     description: 生成 PPT 演示文稿，支持一句话生成
-    model: gemini_maas_pro_20260219
-    temperature: 0.2
+    temperature: 1.0
     tools: ["serper_search", "fetch_url", "read_file", "write_file", "bash_command", "send_message", "image_search", "ask_user", "memory_search"]
     skills: ["ppt-superpower", "ppt-asset-plan", "ppt-html-gen", "ppt-image-selection", "ppt-page-assets", "ppt-page-html", "ppt-page-plan", "ppt-page-polish", "ppt-research-pack", "ppt-review", "ppt-source-analysis", "ppt-speaker-notes", "ppt-story-refine", "ppt-storyboard", "ppt-style-refine", "ppt-style-spec", "ppt-task-pack", "ppt-template-pack"]
     max_send_depth: 2
@@ -210,8 +215,7 @@ agents:
   data-analyst:
     name: 数据分析助手
     description: 数据分析、可视化和报告生成
-    model: gemini_maas_pro_20260219
-    temperature: 0.2
+    temperature: 1.0
     tools: ["read_file", "write_file", "bash_command", "send_message", "feishu_doc", "feishu-wiki", "ask_user", "memory_search"]
     skills: ["excel-xlsx", "python-dataviz", "pdf", "csv-pipeline", "mineru-document-extractor", "openai-whisper-api"]
     max_send_depth: 2
@@ -220,8 +224,7 @@ agents:
   doc-organizer:
     name: 文档整理助手
     description: 处理多种来源的文档，支持格式转换和整理
-    model: gemini_maas_pro_20260219
-    temperature: 0.2
+    temperature: 1.0
     tools: ["read_file", "write_file", "bash_command", "send_message", "feishu_doc", "feishu-wiki", "feishu-drive", "ask_user", "memory_search"]
     skills: ["markdown-converter", "docx-cn", "excel-xlsx", "pdf", "pdf-generator", "mineru-document-extractor", "openai-whisper-api", "feishu-doc", "feishu-wiki", "feishu-drive"]
     max_send_depth: 2
@@ -230,8 +233,7 @@ agents:
   email-agent:
     name: 邮件助手
     description: 邮件收发、管理和定时提醒
-    model: gemini_maas_pro_20260219
-    temperature: 0.2
+    temperature: 1.0
     tools: ["bash_command", "read_file", "write_file", "send_message", "send_email", "list_emails", "read_email", "download_attachment", "mark_email", "search_emails", "ask_user", "memory_search"]
     skills: []
     max_send_depth: 2
@@ -240,8 +242,7 @@ agents:
   search-agent:
     name: 搜索调研助手
     description: 深度调研特定主题，多轮搜索+内容抓取+生成报告
-    model: gemini_maas_pro_20260219
-    temperature: 0.2
+    temperature: 1.0
     tools: ["serper_search", "fetch_url", "read_file", "write_file", "bash_command", "image_search", "send_message", "ask_user", "memory_search"]
     skills: ["mineru-document-extractor", "research-union", "union-search-plus"]
     max_send_depth: 2

--- a/sensenova_claw/adapters/llm/base.py
+++ b/sensenova_claw/adapters/llm/base.py
@@ -2,6 +2,19 @@ from __future__ import annotations
 
 from typing import Any, AsyncIterator
 
+DEFAULT_LLM_TEMPERATURE = 1.0
+DEFAULT_SAMPLING_EXTRA_BODY: dict[str, Any] = {
+    "top_p": 0.95,
+    "top_k": 20,
+}
+
+
+def merge_sampling_extra_body(extra_body: dict[str, Any] | None = None) -> dict[str, Any]:
+    merged = dict(DEFAULT_SAMPLING_EXTRA_BODY)
+    if extra_body:
+        merged.update(extra_body)
+    return merged
+
 
 class LLMProvider:
     async def call(
@@ -9,7 +22,7 @@ class LLMProvider:
         model: str,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
-        temperature: float = 0.2,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
         max_tokens: int | None = None,
         extra_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
@@ -20,7 +33,7 @@ class LLMProvider:
         model: str,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
-        temperature: float = 0.2,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
         max_tokens: int | None = None,
         extra_body: dict[str, Any] | None = None,
     ) -> AsyncIterator[dict[str, Any]]:

--- a/sensenova_claw/adapters/llm/providers/anthropic_provider.py
+++ b/sensenova_claw/adapters/llm/providers/anthropic_provider.py
@@ -6,7 +6,11 @@ from typing import Any, AsyncIterator
 from anthropic import AsyncAnthropic
 
 from sensenova_claw.platform.config.config import config
-from sensenova_claw.adapters.llm.base import LLMProvider
+from sensenova_claw.adapters.llm.base import (
+    DEFAULT_LLM_TEMPERATURE,
+    LLMProvider,
+    merge_sampling_extra_body,
+)
 
 
 class AnthropicProvider(LLMProvider):
@@ -25,7 +29,7 @@ class AnthropicProvider(LLMProvider):
         model: str,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
-        temperature: float = 0.2,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
         max_tokens: int | None = None,
         extra_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
@@ -49,7 +53,10 @@ class AnthropicProvider(LLMProvider):
         if tools:
             req["tools"] = [self._convert_tool(t) for t in tools]
 
-        response = await self.client.messages.create(**req, extra_body=extra_body)
+        response = await self.client.messages.create(
+            **req,
+            extra_body=merge_sampling_extra_body(extra_body),
+        )
 
         content_text = ""
         tool_calls: list[dict[str, Any]] = []
@@ -80,7 +87,7 @@ class AnthropicProvider(LLMProvider):
         model: str,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
-        temperature: float = 0.2,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
         max_tokens: int | None = None,
         extra_body: dict[str, Any] | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
@@ -104,7 +111,10 @@ class AnthropicProvider(LLMProvider):
         tool_idx = 0
         usage: dict[str, int] = {}
 
-        async with self.client.messages.stream(**req, extra_body=extra_body) as stream:
+        async with self.client.messages.stream(
+            **req,
+            extra_body=merge_sampling_extra_body(extra_body),
+        ) as stream:
             async for event in stream:
                 if event.type == "content_block_start":
                     block = event.content_block

--- a/sensenova_claw/adapters/llm/providers/gemini_provider.py
+++ b/sensenova_claw/adapters/llm/providers/gemini_provider.py
@@ -8,7 +8,11 @@ from typing import Any, AsyncIterator
 from openai import AsyncOpenAI
 
 from sensenova_claw.platform.config.config import config
-from sensenova_claw.adapters.llm.base import LLMProvider
+from sensenova_claw.adapters.llm.base import (
+    DEFAULT_LLM_TEMPERATURE,
+    LLMProvider,
+    merge_sampling_extra_body,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -86,6 +90,7 @@ class GeminiProvider(LLMProvider):
         可以绕过 SDK 的 TypedDict 序列化，保留所有字段。
         """
         merged = dict(extra_body) if extra_body else {}
+        merged = merge_sampling_extra_body(merged)
         merged["messages"] = normalized_messages
         return merged
 
@@ -94,7 +99,7 @@ class GeminiProvider(LLMProvider):
         model: str,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
-        temperature: float = 0.2,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
         max_tokens: int | None = None,
         extra_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
@@ -186,7 +191,7 @@ class GeminiProvider(LLMProvider):
         model: str,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
-        temperature: float = 0.2,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
         max_tokens: int | None = None,
         extra_body: dict[str, Any] | None = None,
     ) -> AsyncIterator[dict[str, Any]]:

--- a/sensenova_claw/adapters/llm/providers/mock_provider.py
+++ b/sensenova_claw/adapters/llm/providers/mock_provider.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from typing import Any
 
-from sensenova_claw.adapters.llm.base import LLMProvider
+from sensenova_claw.adapters.llm.base import DEFAULT_LLM_TEMPERATURE, LLMProvider
 
 
 class MockProvider(LLMProvider):
@@ -11,7 +11,7 @@ class MockProvider(LLMProvider):
         model: str,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
-        temperature: float = 0.2,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
         max_tokens: int | None = None,
         extra_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:

--- a/sensenova_claw/adapters/llm/providers/openai_provider.py
+++ b/sensenova_claw/adapters/llm/providers/openai_provider.py
@@ -6,7 +6,11 @@ from typing import Any, AsyncIterator
 from openai import AsyncOpenAI
 
 from sensenova_claw.platform.config.config import config
-from sensenova_claw.adapters.llm.base import LLMProvider
+from sensenova_claw.adapters.llm.base import (
+    DEFAULT_LLM_TEMPERATURE,
+    LLMProvider,
+    merge_sampling_extra_body,
+)
 
 
 class OpenAIProvider(LLMProvider):
@@ -25,11 +29,12 @@ class OpenAIProvider(LLMProvider):
         model: str,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
-        temperature: float = 0.2,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
         max_tokens: int | None = None,
         extra_body: dict[str, Any] | None = None,
     ) -> dict[str, Any]:
         normalized_messages = self._normalize_messages(messages)
+        merged_extra_body = merge_sampling_extra_body(extra_body)
         req: dict[str, Any] = {
             "model": model,
             "messages": normalized_messages,
@@ -39,8 +44,8 @@ class OpenAIProvider(LLMProvider):
             req["tools"] = [{"type": "function", "function": t} for t in tools]
         if max_tokens:
             req["max_tokens"] = max_tokens
-        if extra_body:
-            req["extra_body"] = extra_body
+        if merged_extra_body:
+            req["extra_body"] = merged_extra_body
 
         response = await self.client.chat.completions.create(**req)
         choice = response.choices[0]
@@ -78,11 +83,12 @@ class OpenAIProvider(LLMProvider):
         model: str,
         messages: list[dict[str, Any]],
         tools: list[dict[str, Any]] | None = None,
-        temperature: float = 0.2,
+        temperature: float = DEFAULT_LLM_TEMPERATURE,
         max_tokens: int | None = None,
         extra_body: dict[str, Any] | None = None,
     ) -> AsyncIterator[dict[str, Any]]:
         normalized_messages = self._normalize_messages(messages)
+        merged_extra_body = merge_sampling_extra_body(extra_body)
         req: dict[str, Any] = {
             "model": model,
             "messages": normalized_messages,
@@ -94,8 +100,8 @@ class OpenAIProvider(LLMProvider):
             req["tools"] = [{"type": "function", "function": t} for t in tools]
         if max_tokens:
             req["max_tokens"] = max_tokens
-        if extra_body:
-            req["extra_body"] = extra_body
+        if merged_extra_body:
+            req["extra_body"] = merged_extra_body
 
         stream = await self.client.chat.completions.create(**req)
         tool_calls_acc: dict[int, dict[str, Any]] = {}

--- a/sensenova_claw/app/web/app/agents/[id]/page.tsx
+++ b/sensenova_claw/app/web/app/agents/[id]/page.tsx
@@ -82,7 +82,7 @@ export default function AgentDetailPage() {
         setEditName(data.name || '');
         setEditDesc(data.description || '');
         setEditModel(data.model || '');
-        setEditTemp(String(data.temperature ?? 0.2));
+        setEditTemp(String(data.temperature ?? 1.0));
         setEditPrompt(data.systemPrompt || '');
         setEditDelegateTo(Array.isArray(data.canDelegateTo) ? data.canDelegateTo : []);
         setEditMaxDepth(String(data.maxDelegationDepth ?? 3));
@@ -128,7 +128,7 @@ export default function AgentDetailPage() {
         name: editName,
         description: editDesc,
         model: editModel || undefined,
-        temperature: parseFloat(editTemp) || 0.2,
+        temperature: parseFloat(editTemp) || 1.0,
         systemPrompt: editPrompt,
         can_delegate_to: editDelegateTo.length > 0 ? editDelegateTo : null,
         max_delegation_depth: parseInt(editMaxDepth) || 3,

--- a/sensenova_claw/app/web/app/agents/page.tsx
+++ b/sensenova_claw/app/web/app/agents/page.tsx
@@ -341,7 +341,7 @@ function CreateAgentModal({ onClose, onCreated }: { onClose: () => void; onCreat
           name: formName.trim(),
           description: formDesc.trim(),
           model: formModel.trim() || undefined,
-          temperature: parseFloat(formTemp) || 0.2,
+          temperature: parseFloat(formTemp) || 1.0,
           system_prompt: formPrompt,
         }),
       });

--- a/sensenova_claw/capabilities/agents/config.py
+++ b/sensenova_claw/capabilities/agents/config.py
@@ -28,7 +28,7 @@ class AgentConfig:
 
     # LLM 配置
     model: str = "gpt-4o-mini"                        # 模型名称（引用 llm.models 中的 key，provider 由 resolve_model 动态解析）
-    temperature: float = 0.2                          # 温度参数
+    temperature: float = 1.0                          # 温度参数
     max_tokens: int | None = None                     # 最大 token 数
     extra_body: dict[str, Any] = field(default_factory=dict)  # 透传给 LLM API 的额外参数
 
@@ -78,7 +78,7 @@ class AgentConfig:
             name=data.get("name", data["id"]),
             description=data.get("description", ""),
             model=data.get("model", "gpt-4o-mini"),
-            temperature=data.get("temperature", 0.2),
+            temperature=data.get("temperature", 1.0),
             max_tokens=data.get("max_tokens"),
             extra_body=dict(data.get("extra_body", {})),
             system_prompt=data.get("system_prompt", ""),

--- a/sensenova_claw/capabilities/agents/registry.py
+++ b/sensenova_claw/capabilities/agents/registry.py
@@ -125,7 +125,7 @@ class AgentRegistry:
             name=agent_dict.get("name", agent_id.replace("-", " ").title() if agent_id != "default" else "Default Agent"),
             description=agent_dict.get("description", "默认 AI Agent" if agent_id == "default" else ""),
             model=agent_dict.get("model", ""),
-            temperature=agent_dict.get("temperature", fallback.get("temperature", 0.2)),
+            temperature=agent_dict.get("temperature", fallback.get("temperature", 1.0)),
             max_tokens=agent_dict.get("max_tokens"),
             system_prompt=system_prompt,
             tools=list(agent_dict.get("tools", [])),

--- a/sensenova_claw/capabilities/memory/manager.py
+++ b/sensenova_claw/capabilities/memory/manager.py
@@ -316,7 +316,7 @@ class MemoryManager:
                 {"role": "user", "content": f"请总结以下对话：\n\n{conversation}"},
             ],
             tools=None,
-            temperature=0.1,
+            temperature=1.0,
             max_tokens=500,
         )
         return str(response.get("content", "") or "")

--- a/sensenova_claw/capabilities/tools/orchestration.py
+++ b/sensenova_claw/capabilities/tools/orchestration.py
@@ -90,7 +90,7 @@ class CreateAgentTool(Tool):
         model = kwargs.get("model") or (default.model if default else "gpt-4o-mini")
         temperature = kwargs.get("temperature")
         if temperature is None:
-            temperature = default.temperature if default else 0.2
+            temperature = default.temperature if default else 1.0
 
         agent = AgentConfig.create(
             id=agent_id,

--- a/sensenova_claw/interfaces/http/agents.py
+++ b/sensenova_claw/interfaces/http/agents.py
@@ -306,7 +306,7 @@ async def create_agent(body: AgentCreate, request: Request):
         name=body.name,
         description=body.description,
         model=body.model or (default.model if default else "gpt-4o-mini"),
-        temperature=body.temperature if body.temperature is not None else (default.temperature if default else 0.2),
+        temperature=body.temperature if body.temperature is not None else (default.temperature if default else 1.0),
         max_tokens=body.max_tokens,
         system_prompt=body.system_prompt,
         tools=body.tools,

--- a/sensenova_claw/kernel/proactive/delivery.py
+++ b/sensenova_claw/kernel/proactive/delivery.py
@@ -60,7 +60,7 @@ class ProactiveDelivery:
                 {"role": "system", "content": summary_prompt},
                 {"role": "user", "content": result},
             ]
-            resp = await provider.call(model=model, messages=messages, temperature=0.3)
+            resp = await provider.call(model=model, messages=messages, temperature=1.0)
             return resp.get("content", result)[:500]
         except Exception as e:
             logger.warning("LLM 摘要失败，回退到原始结果: %s", e)

--- a/sensenova_claw/kernel/runtime/context_compressor.py
+++ b/sensenova_claw/kernel/runtime/context_compressor.py
@@ -439,7 +439,7 @@ class ContextCompressor:
             resp = await provider.call(
                 model=self._model,
                 messages=[{"role": "user", "content": prompt}],
-                temperature=0.1,
+                temperature=1.0,
                 max_tokens=max_tokens * 2,
             )
             summary = resp.get("content", "")
@@ -450,7 +450,7 @@ class ContextCompressor:
                 resp = await provider.call(
                     model=self._model,
                     messages=[{"role": "user", "content": re_prompt}],
-                    temperature=0.1,
+                    temperature=1.0,
                     max_tokens=max_tokens * 2,
                 )
                 summary = resp.get("content", summary)

--- a/sensenova_claw/kernel/runtime/title_runtime.py
+++ b/sensenova_claw/kernel/runtime/title_runtime.py
@@ -92,7 +92,7 @@ class TitleRuntime:
                 {"role": "user", "content": f"用户问题：{user_input}\n\n请生成会话标题："},
             ]
 
-            response = await provider.call(model=model, messages=messages, tools=None, temperature=0.7)
+            response = await provider.call(model=model, messages=messages, tools=None, temperature=1.0)
             title = response.get("content", "").strip()
 
             if len(title) > 10:

--- a/sensenova_claw/kernel/runtime/workers/agent_worker.py
+++ b/sensenova_claw/kernel/runtime/workers/agent_worker.py
@@ -95,7 +95,7 @@ class AgentSessionWorker(SessionWorker):
     def _get_temperature(self) -> float:
         if self.agent_config:
             return self.agent_config.temperature
-        return config.get("agent.temperature", 0.2)
+        return config.get("agent.temperature", 1.0)
 
     def _get_max_tokens(self) -> int:
         """获取 max_output_tokens：agent 级别覆盖 model 级别"""
@@ -106,8 +106,9 @@ class AgentSessionWorker(SessionWorker):
 
     def _get_extra_body(self) -> dict:
         """获取 extra_body：agent 级别覆盖 model 级别"""
+        model_extra = dict(config.get("agent.extra_body", {}))
         model_key = self._get_model_key()
-        model_extra = config.get_model_extra_body(model_key)
+        model_extra.update(config.get_model_extra_body(model_key))
         if self.agent_config and self.agent_config.extra_body:
             model_extra.update(self.agent_config.extra_body)
         return model_extra

--- a/sensenova_claw/kernel/runtime/workers/llm_worker.py
+++ b/sensenova_claw/kernel/runtime/workers/llm_worker.py
@@ -34,6 +34,13 @@ logger = logging.getLogger(__name__)
 _LLM_DEBUG = os.environ.get("SENSENOVA_CLAW_DEBUG_LLM", "").strip() not in ("", "0", "false")
 
 
+def _merge_default_extra_body(extra_body: dict[str, Any] | None) -> dict[str, Any]:
+    merged = dict(config.get("agent.extra_body", {}))
+    if extra_body:
+        merged.update(extra_body)
+    return merged
+
+
 def _normalize_llm_error(provider_name: str, model: str, error_message: str) -> dict[str, Any]:
     """将 provider 原始错误归一化为更友好的前端可消费结构。"""
     context: dict[str, Any] = {"model": model, "provider": provider_name}
@@ -751,9 +758,9 @@ class LLMSessionWorker(SessionWorker):
             provider_name, model = config.resolve_model(model_key)
         messages = event.payload.get("messages", [])
         tools = event.payload.get("tools")
-        temperature = float(event.payload.get("temperature", config.get("agent.temperature", 0.2)))
+        temperature = float(event.payload.get("temperature", config.get("agent.temperature", 1.0)))
         max_tokens = event.payload.get("max_tokens")
-        extra_body = event.payload.get("extra_body") or None
+        extra_body = _merge_default_extra_body(event.payload.get("extra_body") or None)
 
         logger.debug(
             "LLM call input | provider=%s model=%s llm_call_id=%s extra_body=%s messages=%s tools=%s",

--- a/sensenova_claw/platform/config/config.py
+++ b/sensenova_claw/platform/config/config.py
@@ -137,7 +137,11 @@ DEFAULT_CONFIG: dict[str, Any] = {
     },
     # agent 段保留作为所有 agent 的后备默认值
     "agent": {
-        "temperature": 0.2,
+        "temperature": 1.0,
+        "extra_body": {
+            "top_p": 0.95,
+            "top_k": 20,
+        },
         "max_turns_per_session": 50,
         "system_prompt": "你是一个有工具能力的AI助手，请在必要时调用工具。",
         "stream": True,
@@ -320,7 +324,7 @@ DEFAULT_CONFIG: dict[str, Any] = {
         "default": {
             "name": "Default Agent",
             "description": "默认 AI Agent",
-            "temperature": 0.2,
+            "temperature": 1.0,
             "tools": [],
             "skills": [],
         },

--- a/tests/unit/test_agent_config.py
+++ b/tests/unit/test_agent_config.py
@@ -23,7 +23,7 @@ class TestAgentConfig:
         a = AgentConfig(id="m", name="M")
         assert a.model == "gpt-4o-mini"
         assert a.enabled is True
-        assert a.temperature == 0.2
+        assert a.temperature == 1.0
         assert a.max_delegation_depth == 3
         assert a.max_pingpong_turns == 10
 

--- a/tests/unit/test_config.py
+++ b/tests/unit/test_config.py
@@ -54,7 +54,12 @@ class TestConfig:
         # 用户覆盖的值
         assert cfg.get("agent.model") == "gpt-5.4"
         # 默认值保留
-        assert cfg.get("agent.temperature") == 0.2
+        assert cfg.get("agent.temperature") == 1.0
+
+    def test_default_agent_sampling_defaults(self, tmp_path):
+        cfg = Config(config_path=tmp_path / "nonexist.yml")
+        assert cfg.get("agent.temperature") == 1.0
+        assert cfg.get("agent.extra_body") == {"top_p": 0.95, "top_k": 20}
 
     def test_set_runtime(self, tmp_path):
         cfg = Config(config_path=tmp_path / "nonexist.yml")

--- a/tests/unit/test_llm_worker.py
+++ b/tests/unit/test_llm_worker.py
@@ -238,6 +238,25 @@ class TestLLMWorkerHandle:
         worker = LLMSessionWorker("s1", private_bus, runtime)
         event = EventEnvelope(type="other.event", session_id="s1")
         await worker._handle(event)
+
+    async def test_applies_default_sampling_when_event_omits_it(self, private_bus, runtime, monkeypatch):
+        provider = _SuccessProvider("ok")
+        runtime.factory.get_provider = lambda provider_name="mock": provider
+        worker = LLMSessionWorker("s1", private_bus, runtime)
+        event = _make_llm_event("mock", "mock-agent-v1", [{"role": "user", "content": "hi"}])
+
+        original_temperature = config.get("agent.temperature")
+        original_extra_body = config.get("agent.extra_body")
+        config.set("agent.temperature", 1.0)
+        config.set("agent.extra_body", {"top_p": 0.95, "top_k": 20})
+        try:
+            await worker._handle_llm_requested(event)
+        finally:
+            config.set("agent.temperature", original_temperature)
+            config.set("agent.extra_body", original_extra_body)
+
+        assert provider.calls[0]["temperature"] == 1.0
+        assert provider.calls[0]["extra_body"] == {"top_p": 0.95, "top_k": 20}
         # 不抛异常即可
 
     @pytest.mark.parametrize("provider_name", ["mock", "gemini"])


### PR DESCRIPTION
## 概要
- 将默认 `temperature` 统一为 `1.0`
- 为 LLM 请求增加默认 `top_p=0.95`、`top_k=20`
- 将直接调用 provider 的标题生成、主动推送摘要、上下文压缩、记忆摘要等特例路径也统一到同一组采样参数
- 同步更新 `config_example.yml`、Agent 创建/编辑默认值与相关单测

## 验证
- `python3` 解析 `config_example.yml` 通过，当前示例里的所有 agent `temperature` 均为 `1.0`
- `.venv/bin/python -m pytest tests/unit/test_config.py::TestConfig::test_default_agent_sampling_defaults tests/unit/test_config.py::TestConfig::test_deep_merge tests/unit/test_agent_config.py::TestAgentConfig::test_defaults tests/unit/test_llm_worker.py::TestLLMWorkerHandle::test_applies_default_sampling_when_event_omits_it -q`
  - 4 passed
- `.venv/bin/python -m pytest tests/unit/test_config.py tests/unit/test_agent_config.py tests/unit/test_llm_worker.py -q`
  - 本次新增/相关默认值用例已通过
  - 但 `tests/unit/test_llm_worker.py` 仍有既有失败，主要集中在流式事件顺序和 fallback 预期，不是本次新增默认值断言导致
