### PR TITLE
fix: 运行时新增 skill 自动发现

### DIFF
--- a/sensenova_claw/capabilities/skills/registry.py
+++ b/sensenova_claw/capabilities/skills/registry.py
@@ -237,6 +237,30 @@ class SkillRegistry:
             pass
         return {}
 
+    def rescan(self, config: dict[str, Any]) -> int:
+        """重新扫描所有目录，发现新增 skill 并加载，返回新增数量。"""
+        count = 0
+        dirs = []
+        if self._builtin_dir and self._builtin_dir.exists():
+            dirs.append(self._builtin_dir)
+        if self._user_dir and self._user_dir.exists():
+            dirs.append(self._user_dir)
+        if self._workspace_dir and self._workspace_dir.exists():
+            dirs.append(self._workspace_dir)
+        extra_dirs = config.get("skills", {}).get("extra_dirs", [])
+        for d in extra_dirs:
+            p = Path(d)
+            if p.exists():
+                dirs.append(p)
+
+        for base_dir in dirs:
+            for skill_md in base_dir.rglob("SKILL.md"):
+                skill = self._parse_skill(skill_md)
+                if skill and skill.name not in self._skills and self._should_load(skill, config):
+                    self._skills[skill.name] = skill
+                    count += 1
+        return count
+
     def get_all(self) -> list[Skill]:
         """获取所有已加载的 skills"""
         return list(self._skills.values())

--- a/sensenova_claw/interfaces/http/skills.py
+++ b/sensenova_claw/interfaces/http/skills.py
@@ -52,8 +52,10 @@ def _parse_skill_metadata(skill) -> dict:
 
 @router.get("")
 async def list_skills(request: Request):
-    """获取所有已加载的 Skills（含分类、依赖状态）"""
+    """获取所有已加载的 Skills（含分类、依赖状态），自动发现新增 skill"""
     skill_registry = request.app.state.skill_registry
+    config = request.app.state.config.data if hasattr(request.app.state.config, 'data') else {}
+    skill_registry.rescan(config)
     skills = []
     for skill in skill_registry.get_all():
         category = _classify_skill(skill)


### PR DESCRIPTION
## Summary
- SkillRegistry 新增 `rescan` 方法，扫描所有 skill 目录发现新增 skill 并加载（不重复添加已有的）
- `GET /api/skills` 返回前自动调用 rescan，服务运行期间新增的 skill 刷新页面即可看到

## Test plan
- [x] rescan 不会重复添加已有 skill
- [ ] 服务运行时在 `~/.sensenova-claw/skills/` 新增 skill 目录，刷新前端 Skills 页面可见

🤖 Generated with [Claude Code](https://claude.com/claude-code)