### PR TITLE
fix: 同一 turn 多轮工具调用后前面的思考过程消失

### DIFF
--- a/sensenova_claw/app/web/components/chat/MessageBubble.tsx
+++ b/sensenova_claw/app/web/components/chat/MessageBubble.tsx
@@ -114,6 +114,8 @@ export function MessageBubble({ msg }: { msg: ChatMessage }) {
       : { answerContent: '', thinkContent: '' },
     [msg.content, msg.role, msg.thinkingContent],
   );
+  // 思考过程默认展开显示。每条 assistant 消息独立持有 thinkingContent，
+  // 同一 turn 中工具调用前后的多条 assistant 会各自显示自己的思考过程。
   const [showThink, setShowThink] = useState(true);
 
   useEffect(() => {

--- a/sensenova_claw/app/web/components/workbench/MiniAppBuildFeed.tsx
+++ b/sensenova_claw/app/web/components/workbench/MiniAppBuildFeed.tsx
@@ -168,7 +168,7 @@ function buildTranscriptMessages(run: BuildRun): BuildFeedItem[] {
         content: assistantDraft.content,
         timestamp: assistantDraft.timestamp,
         thinkingContent: assistantDraft.thinkingContent || undefined,
-        thinkingState: assistantDraft.thinkingContent ? 'collapsed' : undefined,
+        thinkingState: assistantDraft.thinkingContent ? 'streaming' : undefined,
       },
     });
     assistantDraft = null;

--- a/sensenova_claw/app/web/contexts/ChatSessionContext.tsx
+++ b/sensenova_claw/app/web/contexts/ChatSessionContext.tsx
@@ -558,6 +558,8 @@ export function ChatSessionProvider({ children }: { children: React.ReactNode })
       case 'agent_thinking':
         setIsTyping(true);
         break;
+      // 流式 LLM 输出：通过 upsertAssistantTurnMessage 追加内容到最后一条同 turnId 消息。
+      // 同一 turn 中工具调用前后会产生多条 assistant 消息，各自独立持有 thinkingContent。
       case 'llm_delta': {
         const turnId = typeof payload.turn_id === 'string' ? payload.turn_id : undefined;
         if (turnId && cancelledTurnIdsRef.current.has(turnId)) {
@@ -681,9 +683,10 @@ export function ChatSessionProvider({ children }: { children: React.ReactNode })
         }
         setMessages((prev) => {
           if (completedTurnId) {
+            // 只更新最后一条同 turnId 的 assistant 消息，保留早期消息的 thinking 不变。
+            // 注意：不设置 thinkingState，思考过程默认展开显示。
             return upsertAssistantTurnMessage(prev, completedTurnId, {
               content: final,
-              thinkingState: 'collapsed',
               keepExistingContentWhenEmpty: true,
             });
           }
@@ -691,15 +694,13 @@ export function ChatSessionProvider({ children }: { children: React.ReactNode })
           for (let i = prev.length - 1; i >= 0; i--) {
             if (prev[i].role === 'assistant') {
               const existing = prev[i];
-              // 如果 llm_result 已经设置了相同内容，只折叠思考状态
+              // 如果 llm_result 已经设置了相同内容，保持不变
               if (existing.content === final || !final) {
-                const next = [...prev];
-                next[i] = { ...next[i], thinkingState: 'collapsed' };
-                return next;
+                return prev;
               }
               // 内容不同时才更新（不创建新消息）
               const next = [...prev];
-              next[i] = { ...next[i], content: final, thinkingState: 'collapsed' };
+              next[i] = { ...next[i], content: final };
               return next;
             }
           }

--- a/sensenova_claw/app/web/lib/chatTypes.ts
+++ b/sensenova_claw/app/web/lib/chatTypes.ts
@@ -14,8 +14,21 @@ export interface ChatMessage {
   role: 'user' | 'assistant' | 'tool' | 'system';
   content: string;
   timestamp: number;
+  /**
+   * 同一 turn 中可能产生多条 assistant 消息（LLM 回复 → 工具调用 → LLM 再次回复），
+   * 它们共享相同的 turnId，但每条消息各自持有独立的 content 和 thinkingContent。
+   * **重要**：更新同 turnId 消息时，只能修改最后一条，不得合并或删除前面的消息，
+   * 否则会丢失早期的思考过程和回复内容。
+   */
   turnId?: string;
+  /** LLM 的思考过程文本，每条 assistant 消息独立持有 */
   thinkingContent?: string;
+  /**
+   * 思考过程的展示状态：
+   * - 'streaming': 展开显示（默认状态，包括流式输出中和输出完成后）
+   * - 'collapsed': 折叠隐藏
+   * 当前策略：思考过程默认展开，不在 turn 完成时自动折叠。
+   */
   thinkingState?: 'streaming' | 'collapsed';
   /** 工具消息在没有 toolInfo 时展示的工具名。 */
   name?: string;
@@ -180,6 +193,16 @@ export function findLatestAssistantTurnMessage(messages: ChatMessage[], turnId: 
   return null;
 }
 
+/**
+ * 更新同一 turn 中最后一条 assistant 消息，或在工具调用后追加新气泡。
+ *
+ * 【核心规则】同一 turnId 可能对应多条 assistant 消息（每次工具调用后 LLM 会产生新回复），
+ * 每条消息各自持有独立的 thinkingContent。本函数只操作最后一条：
+ *   - 最后一条之后没有 tool 消息 → 原地更新（流式追加内容）
+ *   - 最后一条之后有 tool 消息 → 追加新气泡（工具调用后的新一轮回复）
+ *
+ * **禁止**合并或删除同 turnId 的早期 assistant 消息，否则会丢失前面的思考过程。
+ */
 export function upsertAssistantTurnMessage(
   messages: ChatMessage[],
   turnId: string,
@@ -232,18 +255,16 @@ export function upsertAssistantTurnMessage(
   const lastIndex = matchingIndices[matchingIndices.length - 1];
   const hasToolAfter = messages.slice(lastIndex + 1).some((message) => message.role === 'tool');
 
-  if (matchingIndices.length === 1 && !hasToolAfter) {
+  if (!hasToolAfter) {
+    // 最后一条 assistant 之后没有 tool → 原地更新最后一条，保留之前的不动
     const next = [...messages];
     next[lastIndex] = nextMessage;
     return next;
   }
 
-  const removedIndices = new Set(matchingIndices);
-  const filtered = messages.filter((_message, index) => !removedIndices.has(index));
-  const duplicateCountBeforeLast = matchingIndices.length - 1;
-  const insertIndex = hasToolAfter ? filtered.length : lastIndex - duplicateCountBeforeLast;
-  filtered.splice(insertIndex, 0, nextMessage);
-  return filtered;
+  // 最后一条 assistant 之后有 tool → 追加新气泡（工具调用后的新一轮回复）
+  // 保留之前所有 assistant 消息不变（它们的 thinking content 各自独立）
+  return [...messages, { ...nextMessage, id: makeId() }];
 }
 
 export function rebuildMessagesFromEvents(events: Record<string, unknown>[]): ChatMessage[] {
@@ -277,7 +298,7 @@ export function rebuildMessagesFromEvents(events: Record<string, unknown>[]): Ch
           rebuilt = upsertAssistantTurnMessage(rebuilt, turnId, {
             content,
             thinkingContent,
-            thinkingState: thinkingContent ? 'collapsed' : undefined,
+            thinkingState: thinkingContent ? 'streaming' : undefined,
           });
         } else {
           rebuilt.push({
@@ -286,7 +307,7 @@ export function rebuildMessagesFromEvents(events: Record<string, unknown>[]): Ch
             content,
             timestamp: Date.now(),
             thinkingContent: thinkingContent || undefined,
-            thinkingState: thinkingContent ? 'collapsed' : undefined,
+            thinkingState: thinkingContent ? 'streaming' : undefined,
           });
         }
       }
@@ -337,7 +358,6 @@ export function rebuildMessagesFromEvents(events: Record<string, unknown>[]): Ch
         if (turnId) {
           rebuilt = upsertAssistantTurnMessage(rebuilt, turnId, {
             content: response,
-            thinkingState: 'collapsed',
             keepExistingContentWhenEmpty: true,
           });
         } else {
@@ -350,10 +370,7 @@ export function rebuildMessagesFromEvents(events: Record<string, unknown>[]): Ch
           }
 
           if (lastAssistantIdx !== -1 && rebuilt[lastAssistantIdx].content === response) {
-            rebuilt[lastAssistantIdx] = {
-              ...rebuilt[lastAssistantIdx],
-              thinkingState: rebuilt[lastAssistantIdx].thinkingContent ? 'collapsed' : undefined,
-            };
+            // 内容相同，保持不变（thinking 默认展开）
           } else if (lastAssistantIdx !== -1 && !rebuilt[lastAssistantIdx].content) {
             rebuilt[lastAssistantIdx] = { ...rebuilt[lastAssistantIdx], content: response };
           } else {


### PR DESCRIPTION
## Summary

- **根因**：`upsertAssistantTurnMessage` 在同一 turnId 存在多条 assistant 消息时（`assistant(thinking1) → tool → assistant(thinking2)`），会删除所有匹配消息再合并为一条，导致工具调用前的思考过程丢失
- **修复 `upsertAssistantTurnMessage`**：只操作最后一条匹配消息——原地更新或在工具后追加新气泡，保留早期消息不变
- **思考过程默认展开**：`turn_completed` 不再设置 `thinkingState: 'collapsed'`，所有思考过程默认展开显示
- **添加关键注释**：在 `ChatMessage` 类型定义、`upsertAssistantTurnMessage` 函数、`turn_completed`/`llm_delta` handler、`MessageBubble` 组件中说明同 turnId 多消息独立性规则，防止回归

## Test plan

- [ ] 触发多轮工具调用的对话（如搜索 + 总结），验证每轮工具调用前后的思考过程都正常显示
- [ ] 切换 session 后重新加载历史消息，验证思考过程正确展示
- [ ] 单轮无工具调用的对话，验证思考过程正常展示
- [ ] 取消正在进行的 turn，验证不影响已有的思考过程展示

🤖 Generated with [Claude Code](https://claude.com/claude-code)