### PR TITLE
feat: 支持生产模式启动前端（next build + next start）

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -7,11 +7,8 @@
 # 或本地执行:
 #   bash install/install.sh
 #
-# 开发模式（跳过克隆，使用当前目录代码）:
+# 开发模式（跳过克隆，使用当前目录代码，不构建前端）:
 #   bash install/install.sh --dev
-#
-# 生产模式（安装后预构建前端，运行时使用 next start）:
-#   bash install/install.sh --production
 #
 set -euo pipefail
 
@@ -24,7 +21,6 @@ REPO_REF="${SENSENOVA_CLAW_REPO_REF:-${SENSENOVA_CLAW_REPO_BRANCH:-dev}}"
 REQUIRED_PYTHON="3.12"
 REQUIRED_NODE="18"
 DEV_MODE=false
-PRODUCTION_MODE=false
 
 # 国内镜像
 CN_NPM_REGISTRY="https://registry.npmmirror.com"
@@ -334,8 +330,8 @@ install_deps() {
   npm install 2>&1 | tail -5
   log "前端依赖安装完成"
 
-  # 4) 生产模式：预构建前端
-  if [ "$PRODUCTION_MODE" = "true" ]; then
+  # 4) 构建前端（--dev 模式跳过）
+  if [ "$DEV_MODE" != "true" ]; then
     info "构建前端生产版本..."
     npm run build 2>&1 | tail -10
     log "前端生产构建完成"
@@ -452,11 +448,8 @@ print_success() {
   if [ "$DEV_MODE" = "true" ]; then
     echo "  模式:     开发模式"
     echo "  代码目录: $APP_DIR"
-  elif [ "$PRODUCTION_MODE" = "true" ]; then
-    echo "  模式:     生产模式（前端已预构建）"
-    echo "  安装目录: $APP_DIR"
-    echo "  安装来源: $REPO_URL@$REPO_REF"
   else
+    echo "  模式:     生产模式（前端已预构建）"
     echo "  安装目录: $APP_DIR"
     echo "  安装来源: $REPO_URL@$REPO_REF"
   fi
@@ -468,13 +461,8 @@ print_success() {
   fi
   echo -e "  ${YELLOW}下一步:${NC}"
   echo ""
-  if [ "$PRODUCTION_MODE" = "true" ]; then
-    echo "    1. 启动服务（生产模式）:"
-    echo "       sensenova-claw run --production"
-  else
-    echo "    1. 启动服务:"
-    echo "       sensenova-claw run"
-  fi
+  echo "    1. 启动服务:"
+  echo "       sensenova-claw run"
   echo ""
   echo "    2. 打开 Web 界面进行 LLM 等配置:"
   echo "       http://localhost:3000"
@@ -493,7 +481,6 @@ main() {
   for arg in "$@"; do
     case "$arg" in
       --dev) DEV_MODE=true ;;
-      --production) PRODUCTION_MODE=true ;;
     esac
   done
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -10,6 +10,9 @@
 # 开发模式（跳过克隆，使用当前目录代码）:
 #   bash install/install.sh --dev
 #
+# 生产模式（安装后预构建前端，运行时使用 next start）:
+#   bash install/install.sh --production
+#
 set -euo pipefail
 
 # ── 配置 ──
@@ -21,6 +24,7 @@ REPO_REF="${SENSENOVA_CLAW_REPO_REF:-${SENSENOVA_CLAW_REPO_BRANCH:-dev}}"
 REQUIRED_PYTHON="3.12"
 REQUIRED_NODE="18"
 DEV_MODE=false
+PRODUCTION_MODE=false
 
 # 国内镜像
 CN_NPM_REGISTRY="https://registry.npmmirror.com"
@@ -328,8 +332,16 @@ install_deps() {
   info "安装前端依赖..."
   cd "$APP_DIR/sensenova_claw/app/web"
   npm install 2>&1 | tail -5
-  cd "$APP_DIR"
   log "前端依赖安装完成"
+
+  # 4) 生产模式：预构建前端
+  if [ "$PRODUCTION_MODE" = "true" ]; then
+    info "构建前端生产版本..."
+    npm run build 2>&1 | tail -10
+    log "前端生产构建完成"
+  fi
+
+  cd "$APP_DIR"
 }
 
 # ── 步骤 5b: 构建 SENSENOVA_CLAW_HOME 目录结构 ──
@@ -440,6 +452,10 @@ print_success() {
   if [ "$DEV_MODE" = "true" ]; then
     echo "  模式:     开发模式"
     echo "  代码目录: $APP_DIR"
+  elif [ "$PRODUCTION_MODE" = "true" ]; then
+    echo "  模式:     生产模式（前端已预构建）"
+    echo "  安装目录: $APP_DIR"
+    echo "  安装来源: $REPO_URL@$REPO_REF"
   else
     echo "  安装目录: $APP_DIR"
     echo "  安装来源: $REPO_URL@$REPO_REF"
@@ -452,8 +468,13 @@ print_success() {
   fi
   echo -e "  ${YELLOW}下一步:${NC}"
   echo ""
-  echo "    1. 启动服务:"
-  echo "       sensenova-claw run"
+  if [ "$PRODUCTION_MODE" = "true" ]; then
+    echo "    1. 启动服务（生产模式）:"
+    echo "       sensenova-claw run --production"
+  else
+    echo "    1. 启动服务:"
+    echo "       sensenova-claw run"
+  fi
   echo ""
   echo "    2. 打开 Web 界面进行 LLM 等配置:"
   echo "       http://localhost:3000"
@@ -472,6 +493,7 @@ main() {
   for arg in "$@"; do
     case "$arg" in
       --dev) DEV_MODE=true ;;
+      --production) PRODUCTION_MODE=true ;;
     esac
   done
 

--- a/sensenova_claw/app/main.py
+++ b/sensenova_claw/app/main.py
@@ -2,7 +2,7 @@
 """Sensenova-Claw 统一 CLI 入口
 
 用法:
-    sensenova-claw run [--port 8000] [--frontend-port 3000] [--no-frontend] [--dev] [--production]
+    sensenova-claw run [--port 8000] [--frontend-port 3000] [--no-frontend] [--dev]
     sensenova-claw cli [--host localhost] [--port 8000] [--agent default] [--session ID] [--debug] [-e MSG]
     sensenova-claw version
 """
@@ -173,7 +173,6 @@ def cmd_run(args: argparse.Namespace) -> int:
     frontend_port = args.frontend_port
     no_frontend = args.no_frontend
     dev_mode = args.dev
-    production_mode = args.production
 
     # --dev 模式：使用当前工作目录的代码
     if dev_mode:
@@ -217,14 +216,15 @@ def cmd_run(args: argparse.Namespace) -> int:
         # 将本地项目根目录置于 PYTHONPATH 最前，确保子进程优先导入本地代码
         env["PYTHONPATH"] = str(project_root) + os.pathsep + env.get("PYTHONPATH", "")
 
-    # 启动后端
+    # 启动后端：有 .next/ 预构建产物时认为是生产环境，不开启热重载
+    is_production = (web_dir / ".next").exists()
     backend_cmd = [
         sys.executable, "-m", "uvicorn",
         "sensenova_claw.app.gateway.main:app",
         "--host", "0.0.0.0",
         "--port", str(backend_port),
     ]
-    if not production_mode:
+    if not is_production:
         backend_cmd.insert(4, "--reload")
     print(f"启动后端服务: http://localhost:{backend_port}")
     backend_proc = _spawn_managed_process(backend_cmd, cwd=str(project_root), env=env)
@@ -236,15 +236,14 @@ def cmd_run(args: argparse.Namespace) -> int:
         cleanup()
         return 1
 
-    # 启动前端
+    # 启动前端：检测到 .next/ 目录（已 build）自动用 next start，否则回退 next dev
     frontend_proc = None
     if not no_frontend:
-        if production_mode:
-            frontend_cmd = _build_frontend_prod_cmd(web_dir, frontend_port)
-            if not frontend_cmd:
-                print("警告: 前端未构建，请先执行 'npm run build' 或使用 --production 安装。回退到开发模式。", file=sys.stderr)
-                frontend_cmd = _build_frontend_dev_cmd(web_dir, frontend_port)
+        frontend_cmd = _build_frontend_prod_cmd(web_dir, frontend_port)
+        if frontend_cmd:
+            print("检测到前端预构建产物，使用 next start（生产模式）")
         else:
+            print("未检测到前端预构建产物，使用 next dev（开发模式）")
             frontend_cmd = _build_frontend_dev_cmd(web_dir, frontend_port)
         if not frontend_cmd:
             print("警告: 未找到可用的 Node.js/npm，跳过前端启动。安装 Node.js 后可使用前端 dashboard。", file=sys.stderr)
@@ -279,7 +278,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     # 后端会在启动时打印 token URL，这里也提示用户
     print()
     print("=" * 50)
-    mode_label = " (dev mode)" if dev_mode else " (production)" if production_mode else ""
+    mode_label = " (dev mode)" if dev_mode else " (production)" if is_production else ""
     print(f"  Sensenova-Claw 已启动{mode_label}")
     print(f"  后端 API:    http://localhost:{backend_port}")
     if dev_mode:
@@ -376,7 +375,6 @@ def main() -> int:
     run_parser.add_argument("--frontend-port", type=int, default=3000, help="前端端口 (默认 3000)")
     run_parser.add_argument("--no-frontend", action="store_true", help="仅启动后端，不启动前端")
     run_parser.add_argument("--dev", action="store_true", help="开发模式：使用当前目录的代码而非安装目录")
-    run_parser.add_argument("--production", action="store_true", help="生产模式：前端使用预构建版本(next start)，后端禁用热重载")
 
     # sensenova_claw cli
     cli_parser = subparsers.add_parser("cli", help="启动 CLI 交互客户端")

--- a/sensenova_claw/app/main.py
+++ b/sensenova_claw/app/main.py
@@ -2,7 +2,7 @@
 """Sensenova-Claw 统一 CLI 入口
 
 用法:
-    sensenova-claw run [--port 8000] [--frontend-port 3000] [--no-frontend] [--dev]
+    sensenova-claw run [--port 8000] [--frontend-port 3000] [--no-frontend] [--dev] [--production]
     sensenova-claw cli [--host localhost] [--port 8000] [--agent default] [--session ID] [--debug] [-e MSG]
     sensenova-claw version
 """
@@ -56,7 +56,7 @@ def _find_node() -> str:
 
 
 def _build_frontend_dev_cmd(web_dir: Path, frontend_port: int) -> list[str]:
-    """优先直接启动 next，避免 Windows 下 npm 包装进程过早退出。"""
+    """优先直接启动 next dev，避免 Windows 下 npm 包装进程过早退出。"""
     next_cli = web_dir / "node_modules" / "next" / "dist" / "bin" / "next"
     node = _find_node()
     if node and next_cli.exists():
@@ -65,6 +65,23 @@ def _build_frontend_dev_cmd(web_dir: Path, frontend_port: int) -> list[str]:
     npm = _find_npm()
     if npm:
         return [npm, "run", "dev", "--", "-p", str(frontend_port)]
+    return []
+
+
+def _build_frontend_prod_cmd(web_dir: Path, frontend_port: int) -> list[str]:
+    """生产模式：使用 next start 启动预构建的前端。"""
+    # 检查是否已经 build 过
+    if not (web_dir / ".next").exists():
+        return []
+
+    next_cli = web_dir / "node_modules" / "next" / "dist" / "bin" / "next"
+    node = _find_node()
+    if node and next_cli.exists():
+        return [node, str(next_cli), "start", "-p", str(frontend_port)]
+
+    npm = _find_npm()
+    if npm:
+        return [npm, "run", "start", "--", "-p", str(frontend_port)]
     return []
 
 
@@ -156,6 +173,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     frontend_port = args.frontend_port
     no_frontend = args.no_frontend
     dev_mode = args.dev
+    production_mode = args.production
 
     # --dev 模式：使用当前工作目录的代码
     if dev_mode:
@@ -203,10 +221,11 @@ def cmd_run(args: argparse.Namespace) -> int:
     backend_cmd = [
         sys.executable, "-m", "uvicorn",
         "sensenova_claw.app.gateway.main:app",
-        "--reload",
         "--host", "0.0.0.0",
         "--port", str(backend_port),
     ]
+    if not production_mode:
+        backend_cmd.insert(4, "--reload")
     print(f"启动后端服务: http://localhost:{backend_port}")
     backend_proc = _spawn_managed_process(backend_cmd, cwd=str(project_root), env=env)
     procs.append(backend_proc)
@@ -220,7 +239,13 @@ def cmd_run(args: argparse.Namespace) -> int:
     # 启动前端
     frontend_proc = None
     if not no_frontend:
-        frontend_cmd = _build_frontend_dev_cmd(web_dir, frontend_port)
+        if production_mode:
+            frontend_cmd = _build_frontend_prod_cmd(web_dir, frontend_port)
+            if not frontend_cmd:
+                print("警告: 前端未构建，请先执行 'npm run build' 或使用 --production 安装。回退到开发模式。", file=sys.stderr)
+                frontend_cmd = _build_frontend_dev_cmd(web_dir, frontend_port)
+        else:
+            frontend_cmd = _build_frontend_dev_cmd(web_dir, frontend_port)
         if not frontend_cmd:
             print("警告: 未找到可用的 Node.js/npm，跳过前端启动。安装 Node.js 后可使用前端 dashboard。", file=sys.stderr)
         elif not (web_dir / "node_modules").exists():
@@ -254,7 +279,8 @@ def cmd_run(args: argparse.Namespace) -> int:
     # 后端会在启动时打印 token URL，这里也提示用户
     print()
     print("=" * 50)
-    print(f"  Sensenova-Claw 已启动" + (" (dev mode)" if dev_mode else ""))
+    mode_label = " (dev mode)" if dev_mode else " (production)" if production_mode else ""
+    print(f"  Sensenova-Claw 已启动{mode_label}")
     print(f"  后端 API:    http://localhost:{backend_port}")
     if dev_mode:
         print(f"  代码目录:    {project_root}")
@@ -350,6 +376,7 @@ def main() -> int:
     run_parser.add_argument("--frontend-port", type=int, default=3000, help="前端端口 (默认 3000)")
     run_parser.add_argument("--no-frontend", action="store_true", help="仅启动后端，不启动前端")
     run_parser.add_argument("--dev", action="store_true", help="开发模式：使用当前目录的代码而非安装目录")
+    run_parser.add_argument("--production", action="store_true", help="生产模式：前端使用预构建版本(next start)，后端禁用热重载")
 
     # sensenova_claw cli
     cli_parser = subparsers.add_parser("cli", help="启动 CLI 交互客户端")


### PR DESCRIPTION
## Summary

- `install/install.sh` 增加 `--production` 参数，安装依赖后自动执行 `npm run build` 预构建前端
- `sensenova-claw run` 增加 `--production` 参数：前端使用 `next start`（预构建），后端禁用 `--reload` 热重载
- 未 build 时自动回退到 dev 模式，默认行为不变

**用法**：
```bash
# 安装时预构建
bash install/install.sh --production

# 启动时使用生产模式
sensenova-claw run --production
```

## Test plan

- [ ] `bash install/install.sh --production` 安装后 `sensenova_claw/app/web/.next/` 目录存在
- [ ] `sensenova-claw run --production` 前端使用 `next start`，后端无 `--reload`
- [ ] `sensenova-claw run`（无参数）行为不变，仍使用 `next dev` + `--reload`
- [ ] 未 build 时 `--production` 自动回退到 dev 模式并打印警告

🤖 Generated with [Claude Code](https://claude.com/claude-code)