### PR TITLE
feat: improve install branch selection and frontend startup mode

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -356,6 +356,16 @@ python的运行先conda activate base, 再uv run python xxx.py
 失败/风险经验：
 - 当前环境下 Playwright 即使能拉起 `next dev` 和 headless Chromium，也可能长时间卡住不返回最终结果；浏览器级回归要和进程内/单元测试分层看，不能把这类环境挂起误判成业务失败。
 
+### 2026-03-27 安装脚本 app 分支变量补充
+
+成功经验：
+- 对安装脚本这类 shell 逻辑，直接在 `tests/unit/test_install_scripts.py` 做脚本文本断言是最低成本回归方式，适合锁定环境变量优先级与关键日志文案。
+- `SENSENOVA_CLAW_APP_BRANCH` 这类更贴近业务语义的新变量，最好放在旧变量 `SENSENOVA_CLAW_REPO_REF` / `SENSENOVA_CLAW_REPO_BRANCH` 之前做兼容回退；这样既不破坏历史用法，也能让新入口更直观。
+- 当前仓库跑 pytest 前通常需要先执行 `UV_CACHE_DIR=/tmp/uv_cache uv sync --extra dev`，否则 `.venv` 和 `uv run` 都可能因缺少 `pytest` 直接失败。
+
+失败/风险经验：
+- 这次仅修改了 `install/install.sh` 和文档，`install/install.ps1` 仍沿用旧变量优先级；后续若要求跨平台一致，需要同步评估 PowerShell 脚本与文档示例。
+
 ### 2026-03-27 ask_user 消息内联补充
 
 成功经验：

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -366,6 +366,16 @@ python的运行先conda activate base, 再uv run python xxx.py
 失败/风险经验：
 - 这次仅修改了 `install/install.sh` 和文档，`install/install.ps1` 仍沿用旧变量优先级；后续若要求跨平台一致，需要同步评估 PowerShell 脚本与文档示例。
 
+### 2026-03-27 PR171 同步补充
+
+成功经验：
+- 对“把某个既有 PR 的相关修改同步到当前分支”这类需求，先用 `gh pr view <id> --json commits,files` 和 `gh pr diff <id> --patch` 确认最终影响文件与提交顺序，再决定是 cherry-pick 整个序列还是手工摘取，能明显减少误带无关改动的风险。
+- 遇到 cherry-pick 冲突时，先保留当前分支独有改动，再仅引入 PR 冲突块里的最小增量，通常比整文件覆盖更稳，尤其是 `main.py` 这类在不同分支上都在演进的入口文件。
+- 给既有测试文件补新用例时必须先检查它是否已有历史断言；这次如果不先对照 `git show HEAD:<file>`，很容易误把原有进程管理测试覆盖掉。
+
+失败/风险经验：
+- `gh pr diff --patch` 展示的是 patch，不是“最终净效果说明”；如果直接照 patch 首个提交去整文件替换，容易把 PR 分支上的上下文改动一并带入当前分支。
+
 ### 2026-03-27 ask_user 消息内联补充
 
 成功经验：

--- a/README.md
+++ b/README.md
@@ -86,8 +86,8 @@ irm https://raw.githubusercontent.com/SenseTime-FVG/sensenova_claw/dev/install/i
 
 > 详细说明见 [install/README.md](install/README.md)
 >
-> 如需验证某个发布分支或 tag，可在安装前指定 `SENSENOVA_CLAW_REPO_REF`，例如:
-> `curl -fsSL https://raw.githubusercontent.com/SenseTime-FVG/sensenova_claw/dev/install/install.sh | SENSENOVA_CLAW_REPO_REF=v0.5.0 bash`
+> 如需验证某个发布分支或 tag，可在安装前指定 `SENSENOVA_CLAW_APP_BRANCH`，例如:
+> `curl -fsSL https://raw.githubusercontent.com/SenseTime-FVG/sensenova_claw/dev/install/install.sh | SENSENOVA_CLAW_APP_BRANCH=v0.5.0 bash`
 
 ### Option B: 手动安装
 

--- a/install/README.md
+++ b/install/README.md
@@ -19,11 +19,12 @@ irm https://raw.githubusercontent.com/SenseTime-FVG/sensenova_claw/dev/install/i
 ### 指定安装版本
 
 安装脚本默认拉取 `dev` 分支，也支持通过环境变量显式指定分支或 tag，便于发布验证与回滚。
+Linux / macOS 安装脚本优先读取 `SENSENOVA_CLAW_APP_BRANCH`，未设置时再回退到兼容变量 `SENSENOVA_CLAW_REPO_REF` / `SENSENOVA_CLAW_REPO_BRANCH`。
 
 Linux / macOS:
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/SenseTime-FVG/sensenova_claw/dev/install/install.sh | SENSENOVA_CLAW_REPO_REF=v0.5.0 bash
+curl -fsSL https://raw.githubusercontent.com/SenseTime-FVG/sensenova_claw/dev/install/install.sh | SENSENOVA_CLAW_APP_BRANCH=v0.5.0 bash
 ```
 
 Windows（PowerShell）:

--- a/install/install.sh
+++ b/install/install.sh
@@ -17,7 +17,8 @@ set -euo pipefail
 SENSENOVA_CLAW_HOME="${SENSENOVA_CLAW_HOME:-$HOME/.sensenova-claw}"
 APP_DIR="$SENSENOVA_CLAW_HOME/app"
 REPO_URL="${SENSENOVA_CLAW_REPO_URL:-https://github.com/SenseTime-FVG/sensenova-claw.git}"
-REPO_REF="${SENSENOVA_CLAW_REPO_REF:-${SENSENOVA_CLAW_REPO_BRANCH:-dev}}"
+# app 目录 clone/update 使用的仓库分支或 tag，兼容旧变量名
+REPO_REF="${SENSENOVA_CLAW_APP_BRANCH:-${SENSENOVA_CLAW_REPO_REF:-${SENSENOVA_CLAW_REPO_BRANCH:-dev}}}"
 REQUIRED_PYTHON="3.12"
 REQUIRED_NODE="18"
 DEV_MODE=false
@@ -275,6 +276,8 @@ install_node() {
 # ── 步骤 4: 克隆/更新仓库 ──
 
 setup_repo() {
+  info "app 目录将使用仓库分支/引用: $REPO_REF"
+
   if [ -d "$APP_DIR/.git" ]; then
     info "更新 Sensenova-Claw ($REPO_REF)..."
     cd "$APP_DIR"

--- a/install/install.sh
+++ b/install/install.sh
@@ -10,6 +10,9 @@
 # 开发模式（跳过克隆，使用当前目录代码）:
 #   bash install/install.sh --dev
 #
+# 生产模式（安装后预构建前端，运行时使用 next start）:
+#   bash install/install.sh --production
+#
 set -euo pipefail
 
 # ── 配置 ──
@@ -22,6 +25,7 @@ REPO_REF="${SENSENOVA_CLAW_APP_BRANCH:-${SENSENOVA_CLAW_REPO_REF:-${SENSENOVA_CL
 REQUIRED_PYTHON="3.12"
 REQUIRED_NODE="18"
 DEV_MODE=false
+PRODUCTION_MODE=false
 
 # 国内镜像
 CN_NPM_REGISTRY="https://registry.npmmirror.com"
@@ -331,8 +335,16 @@ install_deps() {
   info "安装前端依赖..."
   cd "$APP_DIR/sensenova_claw/app/web"
   npm install 2>&1 | tail -5
-  cd "$APP_DIR"
   log "前端依赖安装完成"
+
+  # 4) 生产模式：预构建前端
+  if [ "$PRODUCTION_MODE" = "true" ]; then
+    info "构建前端生产版本..."
+    npm run build 2>&1 | tail -10
+    log "前端生产构建完成"
+  fi
+
+  cd "$APP_DIR"
 }
 
 # ── 步骤 5b: 构建 SENSENOVA_CLAW_HOME 目录结构 ──
@@ -443,6 +455,10 @@ print_success() {
   if [ "$DEV_MODE" = "true" ]; then
     echo "  模式:     开发模式"
     echo "  代码目录: $APP_DIR"
+  elif [ "$PRODUCTION_MODE" = "true" ]; then
+    echo "  模式:     生产模式（前端已预构建）"
+    echo "  安装目录: $APP_DIR"
+    echo "  安装来源: $REPO_URL@$REPO_REF"
   else
     echo "  安装目录: $APP_DIR"
     echo "  安装来源: $REPO_URL@$REPO_REF"
@@ -455,8 +471,13 @@ print_success() {
   fi
   echo -e "  ${YELLOW}下一步:${NC}"
   echo ""
-  echo "    1. 启动服务:"
-  echo "       sensenova-claw run"
+  if [ "$PRODUCTION_MODE" = "true" ]; then
+    echo "    1. 启动服务（生产模式）:"
+    echo "       sensenova-claw run --production"
+  else
+    echo "    1. 启动服务:"
+    echo "       sensenova-claw run"
+  fi
   echo ""
   echo "    2. 打开 Web 界面进行 LLM 等配置:"
   echo "       http://localhost:3000"
@@ -475,6 +496,7 @@ main() {
   for arg in "$@"; do
     case "$arg" in
       --dev) DEV_MODE=true ;;
+      --production) PRODUCTION_MODE=true ;;
     esac
   done
 

--- a/install/install.sh
+++ b/install/install.sh
@@ -7,11 +7,8 @@
 # 或本地执行:
 #   bash install/install.sh
 #
-# 开发模式（跳过克隆，使用当前目录代码）:
+# 开发模式（跳过克隆，使用当前目录代码，不构建前端）:
 #   bash install/install.sh --dev
-#
-# 生产模式（安装后预构建前端，运行时使用 next start）:
-#   bash install/install.sh --production
 #
 set -euo pipefail
 
@@ -25,7 +22,6 @@ REPO_REF="${SENSENOVA_CLAW_APP_BRANCH:-${SENSENOVA_CLAW_REPO_REF:-${SENSENOVA_CL
 REQUIRED_PYTHON="3.12"
 REQUIRED_NODE="18"
 DEV_MODE=false
-PRODUCTION_MODE=false
 
 # 国内镜像
 CN_NPM_REGISTRY="https://registry.npmmirror.com"
@@ -337,8 +333,8 @@ install_deps() {
   npm install 2>&1 | tail -5
   log "前端依赖安装完成"
 
-  # 4) 生产模式：预构建前端
-  if [ "$PRODUCTION_MODE" = "true" ]; then
+  # 4) 构建前端（--dev 模式跳过）
+  if [ "$DEV_MODE" != "true" ]; then
     info "构建前端生产版本..."
     npm run build 2>&1 | tail -10
     log "前端生产构建完成"
@@ -455,11 +451,8 @@ print_success() {
   if [ "$DEV_MODE" = "true" ]; then
     echo "  模式:     开发模式"
     echo "  代码目录: $APP_DIR"
-  elif [ "$PRODUCTION_MODE" = "true" ]; then
-    echo "  模式:     生产模式（前端已预构建）"
-    echo "  安装目录: $APP_DIR"
-    echo "  安装来源: $REPO_URL@$REPO_REF"
   else
+    echo "  模式:     生产模式（前端已预构建）"
     echo "  安装目录: $APP_DIR"
     echo "  安装来源: $REPO_URL@$REPO_REF"
   fi
@@ -471,13 +464,8 @@ print_success() {
   fi
   echo -e "  ${YELLOW}下一步:${NC}"
   echo ""
-  if [ "$PRODUCTION_MODE" = "true" ]; then
-    echo "    1. 启动服务（生产模式）:"
-    echo "       sensenova-claw run --production"
-  else
-    echo "    1. 启动服务:"
-    echo "       sensenova-claw run"
-  fi
+  echo "    1. 启动服务:"
+  echo "       sensenova-claw run"
   echo ""
   echo "    2. 打开 Web 界面进行 LLM 等配置:"
   echo "       http://localhost:3000"
@@ -496,7 +484,6 @@ main() {
   for arg in "$@"; do
     case "$arg" in
       --dev) DEV_MODE=true ;;
-      --production) PRODUCTION_MODE=true ;;
     esac
   done
 

--- a/sensenova_claw/app/main.py
+++ b/sensenova_claw/app/main.py
@@ -2,7 +2,7 @@
 """Sensenova-Claw 统一 CLI 入口
 
 用法:
-    sensenova-claw run [--port 8000] [--frontend-port 3000] [--no-frontend] [--dev] [--production]
+    sensenova-claw run [--port 8000] [--frontend-port 3000] [--no-frontend] [--dev]
     sensenova-claw cli [--host localhost] [--port 8000] [--agent default] [--session ID] [--debug] [-e MSG]
     sensenova-claw version
 """
@@ -152,7 +152,6 @@ def cmd_run(args: argparse.Namespace) -> int:
     frontend_port = args.frontend_port
     no_frontend = args.no_frontend
     dev_mode = args.dev
-    production_mode = args.production
 
     # --dev 模式：使用当前工作目录的代码
     if dev_mode:
@@ -190,14 +189,15 @@ def cmd_run(args: argparse.Namespace) -> int:
         # 将本地项目根目录置于 PYTHONPATH 最前，确保子进程优先导入本地代码
         env["PYTHONPATH"] = str(project_root) + os.pathsep + env.get("PYTHONPATH", "")
 
-    # 启动后端
+    # 启动后端：有 .next/ 预构建产物时认为是生产环境，不开启热重载
+    is_production = (web_dir / ".next").exists()
     backend_cmd = [
         sys.executable, "-m", "uvicorn",
         "sensenova_claw.app.gateway.main:app",
         "--host", "0.0.0.0",
         "--port", str(backend_port),
     ]
-    if not production_mode:
+    if not is_production:
         backend_cmd.insert(4, "--reload")
     print(f"启动后端服务: http://localhost:{backend_port}")
     backend_proc = _spawn_managed_process(backend_cmd, cwd=str(project_root), env=env)
@@ -209,15 +209,14 @@ def cmd_run(args: argparse.Namespace) -> int:
         print("错误: 后端启动失败", file=sys.stderr)
         return 1
 
-    # 启动前端
+    # 启动前端：检测到 .next/ 目录（已 build）自动用 next start，否则回退 next dev
     frontend_proc = None
     if not no_frontend:
-        if production_mode:
-            frontend_cmd = _build_frontend_prod_cmd(web_dir, frontend_port)
-            if not frontend_cmd:
-                print("警告: 前端未构建，请先执行 'npm run build' 或使用 --production 安装。回退到开发模式。", file=sys.stderr)
-                frontend_cmd = _build_frontend_dev_cmd(web_dir, frontend_port)
+        frontend_cmd = _build_frontend_prod_cmd(web_dir, frontend_port)
+        if frontend_cmd:
+            print("检测到前端预构建产物，使用 next start（生产模式）")
         else:
+            print("未检测到前端预构建产物，使用 next dev（开发模式）")
             frontend_cmd = _build_frontend_dev_cmd(web_dir, frontend_port)
         if not frontend_cmd:
             print("警告: 未找到可用的 Node.js/npm，跳过前端启动。安装 Node.js 后可使用前端 dashboard。", file=sys.stderr)
@@ -253,7 +252,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     # 后端会在启动时打印 token URL，这里也提示用户
     print()
     print("=" * 50)
-    mode_label = " (dev mode)" if dev_mode else " (production)" if production_mode else ""
+    mode_label = " (dev mode)" if dev_mode else " (production)" if is_production else ""
     print(f"  Sensenova-Claw 已启动{mode_label}")
     print(f"  后端 API:    http://localhost:{backend_port}")
     if dev_mode:
@@ -348,7 +347,6 @@ def main() -> int:
     run_parser.add_argument("--frontend-port", type=int, default=3000, help="前端端口 (默认 3000)")
     run_parser.add_argument("--no-frontend", action="store_true", help="仅启动后端，不启动前端")
     run_parser.add_argument("--dev", action="store_true", help="开发模式：使用当前目录的代码而非安装目录")
-    run_parser.add_argument("--production", action="store_true", help="生产模式：前端使用预构建版本(next start)，后端禁用热重载")
 
     # sensenova_claw cli
     cli_parser = subparsers.add_parser("cli", help="启动 CLI 交互客户端")

--- a/sensenova_claw/app/main.py
+++ b/sensenova_claw/app/main.py
@@ -2,7 +2,7 @@
 """Sensenova-Claw 统一 CLI 入口
 
 用法:
-    sensenova-claw run [--port 8000] [--frontend-port 3000] [--no-frontend] [--dev]
+    sensenova-claw run [--port 8000] [--frontend-port 3000] [--no-frontend] [--dev] [--production]
     sensenova-claw cli [--host localhost] [--port 8000] [--agent default] [--session ID] [--debug] [-e MSG]
     sensenova-claw version
 """
@@ -45,7 +45,44 @@ def _find_npm() -> str:
         return ""
     return npm
 
+def _find_node() -> str:
+    """查找 node 可执行文件路径。"""
+    import shutil
 
+    node = shutil.which("node")
+    if not node:
+        return ""
+    return node
+
+
+def _build_frontend_dev_cmd(web_dir: Path, frontend_port: int) -> list[str]:
+    """优先直接启动 next dev，避免 Windows 下 npm 包装进程过早退出。"""
+    next_cli = web_dir / "node_modules" / "next" / "dist" / "bin" / "next"
+    node = _find_node()
+    if node and next_cli.exists():
+        return [node, str(next_cli), "dev", "-p", str(frontend_port)]
+
+    npm = _find_npm()
+    if npm:
+        return [npm, "run", "dev", "--", "-p", str(frontend_port)]
+    return []
+
+
+def _build_frontend_prod_cmd(web_dir: Path, frontend_port: int) -> list[str]:
+    """生产模式：使用 next start 启动预构建的前端。"""
+    # 检查是否已经 build 过
+    if not (web_dir / ".next").exists():
+        return []
+
+    next_cli = web_dir / "node_modules" / "next" / "dist" / "bin" / "next"
+    node = _find_node()
+    if node and next_cli.exists():
+        return [node, str(next_cli), "start", "-p", str(frontend_port)]
+
+    npm = _find_npm()
+    if npm:
+        return [npm, "run", "start", "--", "-p", str(frontend_port)]
+    return []
 def _spawn_managed_process(
     cmd: list[str],
     *,
@@ -115,6 +152,7 @@ def cmd_run(args: argparse.Namespace) -> int:
     frontend_port = args.frontend_port
     no_frontend = args.no_frontend
     dev_mode = args.dev
+    production_mode = args.production
 
     # --dev 模式：使用当前工作目录的代码
     if dev_mode:
@@ -156,10 +194,11 @@ def cmd_run(args: argparse.Namespace) -> int:
     backend_cmd = [
         sys.executable, "-m", "uvicorn",
         "sensenova_claw.app.gateway.main:app",
-        "--reload",
         "--host", "0.0.0.0",
         "--port", str(backend_port),
     ]
+    if not production_mode:
+        backend_cmd.insert(4, "--reload")
     print(f"启动后端服务: http://localhost:{backend_port}")
     backend_proc = _spawn_managed_process(backend_cmd, cwd=str(project_root), env=env)
     procs.append(backend_proc)
@@ -173,9 +212,15 @@ def cmd_run(args: argparse.Namespace) -> int:
     # 启动前端
     frontend_proc = None
     if not no_frontend:
-        npm = _find_npm()
-        if not npm:
-            print("警告: 未找到 npm，跳过前端启动。安装 Node.js 后可使用前端 dashboard。", file=sys.stderr)
+        if production_mode:
+            frontend_cmd = _build_frontend_prod_cmd(web_dir, frontend_port)
+            if not frontend_cmd:
+                print("警告: 前端未构建，请先执行 'npm run build' 或使用 --production 安装。回退到开发模式。", file=sys.stderr)
+                frontend_cmd = _build_frontend_dev_cmd(web_dir, frontend_port)
+        else:
+            frontend_cmd = _build_frontend_dev_cmd(web_dir, frontend_port)
+        if not frontend_cmd:
+            print("警告: 未找到可用的 Node.js/npm，跳过前端启动。安装 Node.js 后可使用前端 dashboard。", file=sys.stderr)
         elif not (web_dir / "node_modules").exists():
             print("警告: 前端依赖未安装，请先执行 'npm install'。跳过前端启动。", file=sys.stderr)
         else:
@@ -183,7 +228,7 @@ def cmd_run(args: argparse.Namespace) -> int:
             frontend_env = env.copy()
             frontend_env["PORT"] = str(frontend_port)
             frontend_proc = _spawn_managed_process(
-                [npm, "run", "dev"],
+                frontend_cmd,
                 cwd=str(web_dir),
                 env=frontend_env,
             )
@@ -208,7 +253,8 @@ def cmd_run(args: argparse.Namespace) -> int:
     # 后端会在启动时打印 token URL，这里也提示用户
     print()
     print("=" * 50)
-    print(f"  Sensenova-Claw 已启动" + (" (dev mode)" if dev_mode else ""))
+    mode_label = " (dev mode)" if dev_mode else " (production)" if production_mode else ""
+    print(f"  Sensenova-Claw 已启动{mode_label}")
     print(f"  后端 API:    http://localhost:{backend_port}")
     if dev_mode:
         print(f"  代码目录:    {project_root}")
@@ -302,6 +348,7 @@ def main() -> int:
     run_parser.add_argument("--frontend-port", type=int, default=3000, help="前端端口 (默认 3000)")
     run_parser.add_argument("--no-frontend", action="store_true", help="仅启动后端，不启动前端")
     run_parser.add_argument("--dev", action="store_true", help="开发模式：使用当前目录的代码而非安装目录")
+    run_parser.add_argument("--production", action="store_true", help="生产模式：前端使用预构建版本(next start)，后端禁用热重载")
 
     # sensenova_claw cli
     cli_parser = subparsers.add_parser("cli", help="启动 CLI 交互客户端")

--- a/tests/unit/test_app_main.py
+++ b/tests/unit/test_app_main.py
@@ -1,14 +1,19 @@
 from __future__ import annotations
 
 import os
-import signal
 import sys
 import time
 from pathlib import Path
 
 import pytest
 
+from sensenova_claw.app import main as app_main
 from sensenova_claw.app.main import _spawn_managed_process, _terminate_managed_process
+
+
+def _touch(path: Path) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text("", encoding="utf-8")
 
 
 @pytest.mark.skipif(os.name == "nt", reason="该测试仅覆盖类 Unix 进程组行为")
@@ -62,3 +67,42 @@ def test_spawn_managed_process_creates_new_process_group(tmp_path: Path):
         assert os.getpgid(proc.pid) == proc.pid
     finally:
         _terminate_managed_process(proc, timeout=1)
+
+
+def test_build_frontend_dev_cmd_prefers_next_cli(tmp_path, monkeypatch):
+    web_dir = tmp_path / "web"
+    next_cli = web_dir / "node_modules" / "next" / "dist" / "bin" / "next"
+    _touch(next_cli)
+
+    monkeypatch.setattr(app_main, "_find_node", lambda: "/usr/bin/node")
+    monkeypatch.setattr(app_main, "_find_npm", lambda: "/usr/bin/npm")
+
+    assert app_main._build_frontend_dev_cmd(web_dir, 3000) == [
+        "/usr/bin/node",
+        str(next_cli),
+        "dev",
+        "-p",
+        "3000",
+    ]
+
+
+def test_build_frontend_prod_cmd_requires_build_artifact(tmp_path, monkeypatch):
+    web_dir = tmp_path / "web"
+    next_cli = web_dir / "node_modules" / "next" / "dist" / "bin" / "next"
+    _touch(next_cli)
+
+    monkeypatch.setattr(app_main, "_find_node", lambda: "")
+    monkeypatch.setattr(app_main, "_find_npm", lambda: "/usr/bin/npm")
+
+    assert app_main._build_frontend_prod_cmd(web_dir, 3000) == []
+
+    (web_dir / ".next").mkdir(parents=True, exist_ok=True)
+
+    assert app_main._build_frontend_prod_cmd(web_dir, 3000) == [
+        "/usr/bin/npm",
+        "run",
+        "start",
+        "--",
+        "-p",
+        "3000",
+    ]

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -15,6 +15,8 @@ def test_install_sh_uses_editable_tool_install():
         in content
     )
     assert 'info "app 目录将使用仓库分支/引用: $REPO_REF"' in content
+    assert 'if [ "$DEV_MODE" != "true" ]; then' in content
+    assert "npm run build 2>&1 | tail -10" in content
 
 
 def test_install_ps1_uses_editable_tool_install():

--- a/tests/unit/test_install_scripts.py
+++ b/tests/unit/test_install_scripts.py
@@ -10,7 +10,11 @@ def test_install_sh_uses_editable_tool_install():
     content = (ROOT / "install" / "install.sh").read_text(encoding="utf-8")
 
     assert "uv tool install --editable --from . --force sensenova-claw" in content
-    assert 'REPO_REF="${SENSENOVA_CLAW_REPO_REF:-${SENSENOVA_CLAW_REPO_BRANCH:-dev}}"' in content
+    assert (
+        'REPO_REF="${SENSENOVA_CLAW_APP_BRANCH:-${SENSENOVA_CLAW_REPO_REF:-${SENSENOVA_CLAW_REPO_BRANCH:-dev}}}"'
+        in content
+    )
+    assert 'info "app 目录将使用仓库分支/引用: $REPO_REF"' in content
 
 
 def test_install_ps1_uses_editable_tool_install():


### PR DESCRIPTION
## Summary
- support `SENSENOVA_CLAW_APP_BRANCH` as the highest-priority env var for the app clone/update ref in `install/install.sh`, while keeping backward compatibility with `SENSENOVA_CLAW_REPO_REF` and `SENSENOVA_CLAW_REPO_BRANCH`
- print the exact branch/ref used during app repo setup and keep the install docs in sync
- make `install/install.sh` build the frontend by default during normal installs and skip the build only in `--dev` mode
- make `sensenova-claw run` automatically detect `.next/` and switch between `next start` and `next dev`, with backend reload behavior aligned to that mode
- add regression tests for install script behavior and frontend command selection in `main.py`

## Test Plan
- `UV_CACHE_DIR=/tmp/uv_cache uv run python -m pytest tests/unit/test_install_scripts.py tests/unit/test_app_main.py`