### PR TITLE
refactor(storage): SQLite repository 改用 asyncio.to_thread + 前端斜杠命令修复

### DIFF
--- a/.sensenova-claw/skills/mineru-document-extractor/SKILL.md
+++ b/.sensenova-claw/skills/mineru-document-extractor/SKILL.md
@@ -1,22 +1,6 @@
 ---
 name: mineru-document-extractor
-description: MinerU document extraction CLI that converts PDFs, images, into Markdown, HTML, LaTeX, or DOCX via the MinerU API. Supports token-free flash extraction for quick start, full extraction with table/formula recognition, web crawling, batch processing, and piped workflows. read_when:- Extracting text from PDF documents - Converting documents to Markdown - - Batch document processing - OCR on scanned documents - Converting PDF to HTML, LaTeX, or DOCX- Parsing document content- Reading PDF files - Extracting tables from documents - Converting Word documents - Quick document parsing without login
-metadata:
-  openclaw:
-    emoji: "📄"
-    install:
-      - id: install-unix
-        kind: download
-        os: ["darwin", "linux"]
-        bins: ["mineru-open-api"]
-        url: https://cdn-mineru.openxlab.org.cn/open-api-cli/install.sh
-        label: Install mineru-open-api (Linux/macOS)
-      - id: install-windows
-        kind: download
-        os: ["win32"]
-        bins: ["mineru-open-api"]
-        url: https://cdn-mineru.openxlab.org.cn/open-api-cli/install.ps1
-        label: Install mineru-open-api (Windows)
+description: 当需要解析 PDF 或文档图片并转换为 Markdown 时使用。此技能基于 MinerU 提取文档中的结构化内容，支持扫描件 OCR，并可按需导出为 Markdown、HTML、LaTeX 或 DOCX。适用于 PDF 转 Markdown、提取 PDF 正文、识别扫描版 PDF、提取表格或公式、批量解析文档等任务。
 ---
 
 # MinerU 渠道选择型文档解析

--- a/sensenova_claw/adapters/storage/repository.py
+++ b/sensenova_claw/adapters/storage/repository.py
@@ -385,7 +385,9 @@ class Repository:
         """聚合最近未消费的 turn_end 下一问推荐。"""
         if limit <= 0:
             return []
+        return await asyncio.to_thread(self._sync_list_pending_recommendations, limit)
 
+    def _sync_list_pending_recommendations(self, limit: int) -> list[dict[str, Any]]:
         conn = self._conn()
         rows = conn.execute(
             """
@@ -457,8 +459,6 @@ class Repository:
             if len(pending) >= limit:
                 break
 
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return pending
 
     async def get_session_turns(self, session_id: str) -> list[dict[str, Any]]:
@@ -653,6 +653,9 @@ class Repository:
 
     async def save_message_record(self, record: MessageRecord) -> None:
         """保存 Agent-to-Agent 消息记录。"""
+        await asyncio.to_thread(self._sync_save_message_record, record)
+
+    def _sync_save_message_record(self, record: MessageRecord) -> None:
         conn = self._conn()
         conn.execute(
             """
@@ -686,8 +689,6 @@ class Repository:
             ),
         )
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def update_message_record(self, record: MessageRecord) -> None:
         """更新 Agent-to-Agent 消息记录。"""
@@ -695,13 +696,14 @@ class Repository:
 
     async def get_message_record(self, record_id: str) -> MessageRecord | None:
         """按记录 ID 查询 Agent-to-Agent 消息记录。"""
+        return await asyncio.to_thread(self._sync_get_message_record, record_id)
+
+    def _sync_get_message_record(self, record_id: str) -> MessageRecord | None:
         conn = self._conn()
         row = conn.execute(
             "SELECT * FROM agent_messages WHERE id = ?",
             (record_id,),
         ).fetchone()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         if not row:
             return None
         return MessageRecord.from_mapping(dict(row))
@@ -711,6 +713,9 @@ class Repository:
         child_session_id: str,
     ) -> MessageRecord | None:
         """按子会话 ID 查询最新一条 Agent-to-Agent 消息记录。"""
+        return await asyncio.to_thread(self._sync_get_message_record_by_child_session, child_session_id)
+
+    def _sync_get_message_record_by_child_session(self, child_session_id: str) -> MessageRecord | None:
         conn = self._conn()
         row = conn.execute(
             """
@@ -721,8 +726,6 @@ class Repository:
             """,
             (child_session_id,),
         ).fetchone()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         if not row:
             return None
         return MessageRecord.from_mapping(dict(row))
@@ -732,6 +735,9 @@ class Repository:
         parent_session_id: str,
     ) -> list[MessageRecord]:
         """查询父会话下仍在运行中的 Agent-to-Agent 消息记录。"""
+        return await asyncio.to_thread(self._sync_list_active_message_records, parent_session_id)
+
+    def _sync_list_active_message_records(self, parent_session_id: str) -> list[MessageRecord]:
         conn = self._conn()
         rows = conn.execute(
             """
@@ -742,8 +748,6 @@ class Repository:
             """,
             (parent_session_id,),
         ).fetchall()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [MessageRecord.from_mapping(dict(row)) for row in rows]
 
     async def prune_sessions(self, max_age_days: int = 30) -> int:
@@ -790,6 +794,9 @@ class Repository:
 
     async def create_cron_job(self, job_data: dict[str, Any]) -> None:
         """插入一条 cron_jobs 记录"""
+        await asyncio.to_thread(self._sync_create_cron_job, job_data)
+
+    def _sync_create_cron_job(self, job_data: dict[str, Any]) -> None:
         conn = self._conn()
         conn.execute(
             """INSERT INTO cron_jobs (id, name, description, schedule_json, session_target,
@@ -810,59 +817,62 @@ class Repository:
             ),
         )
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def get_cron_job(self, job_id: str) -> dict[str, Any] | None:
         """按 ID 查询单条 cron job"""
+        return await asyncio.to_thread(self._sync_get_cron_job, job_id)
+
+    def _sync_get_cron_job(self, job_id: str) -> dict[str, Any] | None:
         conn = self._conn()
         row = conn.execute("SELECT * FROM cron_jobs WHERE id = ?", (job_id,)).fetchone()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return dict(row) if row else None
 
     async def list_cron_jobs(self, enabled_only: bool = False) -> list[dict[str, Any]]:
         """返回所有 cron jobs"""
+        return await asyncio.to_thread(self._sync_list_cron_jobs, enabled_only)
+
+    def _sync_list_cron_jobs(self, enabled_only: bool) -> list[dict[str, Any]]:
         conn = self._conn()
         if enabled_only:
             rows = conn.execute("SELECT * FROM cron_jobs WHERE enabled = 1 ORDER BY created_at_ms").fetchall()
         else:
             rows = conn.execute("SELECT * FROM cron_jobs ORDER BY created_at_ms").fetchall()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     async def update_cron_job(self, job_id: str, updates: dict[str, Any]) -> None:
         """更新 cron job 的指定字段"""
         if not updates:
             return
+        await asyncio.to_thread(self._sync_update_cron_job, job_id, updates)
+
+    def _sync_update_cron_job(self, job_id: str, updates: dict[str, Any]) -> None:
         set_parts = [f"{k} = ?" for k in updates]
         values = list(updates.values()) + [job_id]
         conn = self._conn()
         conn.execute(f"UPDATE cron_jobs SET {', '.join(set_parts)} WHERE id = ?", values)
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def delete_cron_job(self, job_id: str, *, keep_runs: bool = False) -> None:
         """删除 cron job。keep_runs=True 时保留 runs 历史（用于自动删除场景）。"""
+        await asyncio.to_thread(self._sync_delete_cron_job, job_id, keep_runs)
+
+    def _sync_delete_cron_job(self, job_id: str, keep_runs: bool) -> None:
         conn = self._conn()
         if not keep_runs:
             conn.execute("DELETE FROM cron_runs WHERE job_id = ?", (job_id,))
         conn.execute("DELETE FROM cron_jobs WHERE id = ?", (job_id,))
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def get_runnable_cron_jobs(self, now_ms: int) -> list[dict[str, Any]]:
         """返回到期且未在执行中的 enabled jobs"""
+        return await asyncio.to_thread(self._sync_get_runnable_cron_jobs, now_ms)
+
+    def _sync_get_runnable_cron_jobs(self, now_ms: int) -> list[dict[str, Any]]:
         conn = self._conn()
         rows = conn.execute(
             "SELECT * FROM cron_jobs WHERE enabled = 1 AND running_at_ms IS NULL AND next_run_at_ms <= ?",
             (now_ms,),
         ).fetchall()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     async def update_cron_job_state(self, job_id: str, state_updates: dict[str, Any]) -> None:
@@ -871,16 +881,20 @@ class Repository:
 
     async def clear_stale_cron_running(self) -> None:
         """启动时清除所有 running_at_ms 残留（上次异常退出）"""
+        await asyncio.to_thread(self._sync_clear_stale_cron_running)
+
+    def _sync_clear_stale_cron_running(self) -> None:
         conn = self._conn()
         conn.execute("UPDATE cron_jobs SET running_at_ms = NULL WHERE running_at_ms IS NOT NULL")
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     # ---------- Cron Runs 表操作 ----------
 
     async def insert_cron_run(self, run_data: dict[str, Any]) -> int:
         """插入一条 cron_runs 记录，返回自增 ID"""
+        return await asyncio.to_thread(self._sync_insert_cron_run, run_data)
+
+    def _sync_insert_cron_run(self, run_data: dict[str, Any]) -> int:
         conn = self._conn()
         cursor = conn.execute(
             """INSERT INTO cron_runs (job_id, started_at_ms, ended_at_ms, status, error,
@@ -897,35 +911,38 @@ class Repository:
         )
         run_id = cursor.lastrowid
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return run_id
 
     async def update_cron_run(self, run_id: int, updates: dict[str, Any]) -> None:
         """更新 cron_runs 记录"""
         if not updates:
             return
+        await asyncio.to_thread(self._sync_update_cron_run, run_id, updates)
+
+    def _sync_update_cron_run(self, run_id: int, updates: dict[str, Any]) -> None:
         set_parts = [f"{k} = ?" for k in updates]
         values = list(updates.values()) + [run_id]
         conn = self._conn()
         conn.execute(f"UPDATE cron_runs SET {', '.join(set_parts)} WHERE id = ?", values)
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def list_cron_runs(self, job_id: str, limit: int = 50) -> list[dict[str, Any]]:
         """按 started_at_ms 倒序列出 job 运行历史。"""
+        return await asyncio.to_thread(self._sync_list_cron_runs, job_id, limit)
+
+    def _sync_list_cron_runs(self, job_id: str, limit: int) -> list[dict[str, Any]]:
         conn = self._conn()
         rows = conn.execute(
             "SELECT * FROM cron_runs WHERE job_id = ? ORDER BY started_at_ms DESC LIMIT ?",
             (job_id, limit),
         ).fetchall()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     async def list_all_cron_runs(self, limit: int = 50, status: str | None = None) -> list[dict[str, Any]]:
         """跨所有 job 列出 cron_runs，并 JOIN cron_jobs 获取 job 名称和 payload。"""
+        return await asyncio.to_thread(self._sync_list_all_cron_runs, limit, status)
+
+    def _sync_list_all_cron_runs(self, limit: int, status: str | None) -> list[dict[str, Any]]:
         conn = self._conn()
         sql = """
             SELECT r.*, j.name AS joined_job_name, j.payload_json
@@ -939,14 +956,15 @@ class Repository:
         sql += " ORDER BY r.started_at_ms DESC LIMIT ?"
         params.append(limit)
         rows = conn.execute(sql, params).fetchall()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     # ---------- Proactive Jobs 表操作 ----------
 
     async def create_proactive_job(self, row: dict[str, Any]) -> None:
         """插入一条 proactive_jobs 记录"""
+        await asyncio.to_thread(self._sync_create_proactive_job, row)
+
+    def _sync_create_proactive_job(self, row: dict[str, Any]) -> None:
         now_ms = int(time.time() * 1000)
         conn = self._conn()
         conn.execute(
@@ -963,19 +981,21 @@ class Repository:
             ),
         )
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def get_proactive_job(self, job_id: str) -> dict[str, Any] | None:
         """按 ID 查询单条 proactive job"""
+        return await asyncio.to_thread(self._sync_get_proactive_job, job_id)
+
+    def _sync_get_proactive_job(self, job_id: str) -> dict[str, Any] | None:
         conn = self._conn()
         row = conn.execute("SELECT * FROM proactive_jobs WHERE id = ?", (job_id,)).fetchone()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return dict(row) if row else None
 
     async def list_proactive_jobs(self, enabled_only: bool = False) -> list[dict[str, Any]]:
         """返回所有 proactive jobs"""
+        return await asyncio.to_thread(self._sync_list_proactive_jobs, enabled_only)
+
+    def _sync_list_proactive_jobs(self, enabled_only: bool) -> list[dict[str, Any]]:
         conn = self._conn()
         if enabled_only:
             rows = conn.execute(
@@ -983,35 +1003,38 @@ class Repository:
             ).fetchall()
         else:
             rows = conn.execute("SELECT * FROM proactive_jobs ORDER BY created_at_ms").fetchall()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     async def update_proactive_job(self, job_id: str, updates: dict[str, Any]) -> None:
         """更新 proactive job 的指定字段"""
         if not updates:
             return
+        await asyncio.to_thread(self._sync_update_proactive_job, job_id, updates)
+
+    def _sync_update_proactive_job(self, job_id: str, updates: dict[str, Any]) -> None:
         set_parts = [f"{k} = ?" for k in updates]
         values = list(updates.values()) + [job_id]
         conn = self._conn()
         conn.execute(f"UPDATE proactive_jobs SET {', '.join(set_parts)} WHERE id = ?", values)
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def delete_proactive_job(self, job_id: str) -> None:
         """删除 proactive job 及其 runs"""
+        await asyncio.to_thread(self._sync_delete_proactive_job, job_id)
+
+    def _sync_delete_proactive_job(self, job_id: str) -> None:
         conn = self._conn()
         conn.execute("DELETE FROM proactive_runs WHERE job_id = ?", (job_id,))
         conn.execute("DELETE FROM proactive_jobs WHERE id = ?", (job_id,))
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     # ---------- Proactive Runs 表操作 ----------
 
     async def create_proactive_run(self, row: dict[str, Any]) -> None:
         """插入一条 proactive_runs 记录"""
+        await asyncio.to_thread(self._sync_create_proactive_run, row)
+
+    def _sync_create_proactive_run(self, row: dict[str, Any]) -> None:
         conn = self._conn()
         conn.execute(
             """INSERT INTO proactive_runs (id, job_id, session_id, status, triggered_by,
@@ -1025,36 +1048,37 @@ class Repository:
             ),
         )
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def update_proactive_run(self, run_id: str, updates: dict[str, Any]) -> None:
         """更新 proactive_runs 记录"""
         if not updates:
             return
+        await asyncio.to_thread(self._sync_update_proactive_run, run_id, updates)
+
+    def _sync_update_proactive_run(self, run_id: str, updates: dict[str, Any]) -> None:
         set_parts = [f"{k} = ?" for k in updates]
         values = list(updates.values()) + [run_id]
         conn = self._conn()
         conn.execute(f"UPDATE proactive_runs SET {', '.join(set_parts)} WHERE id = ?", values)
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def list_proactive_runs(self, job_id: str, limit: int = 50) -> list[dict[str, Any]]:
         """按 started_at_ms 倒序列出 job 运行历史"""
+        return await asyncio.to_thread(self._sync_list_proactive_runs, job_id, limit)
+
+    def _sync_list_proactive_runs(self, job_id: str, limit: int) -> list[dict[str, Any]]:
         conn = self._conn()
         rows = conn.execute(
             "SELECT * FROM proactive_runs WHERE job_id = ? ORDER BY started_at_ms DESC LIMIT ?",
             (job_id, limit),
         ).fetchall()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     async def get_proactive_run(self, run_id: str) -> dict[str, Any] | None:
         """按 ID 查询单条 proactive run"""
+        return await asyncio.to_thread(self._sync_get_proactive_run, run_id)
+
+    def _sync_get_proactive_run(self, run_id: str) -> dict[str, Any] | None:
         conn = self._conn()
         row = conn.execute("SELECT * FROM proactive_runs WHERE id = ?", (run_id,)).fetchone()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return dict(row) if row else None

--- a/sensenova_claw/adapters/storage/repository.py
+++ b/sensenova_claw/adapters/storage/repository.py
@@ -499,25 +499,6 @@ class Repository:
         except (json.JSONDecodeError, TypeError, ValueError):
             return False
         return str(meta.get("visibility", "")).strip().lower() == "hidden"
-        # 回填：从 meta JSON 中提取 agent_id 写入 agent_id 列（修复历史数据）
-        rows = conn.execute(
-            "SELECT session_id, meta FROM sessions WHERE agent_id IS NULL OR agent_id = 'default'"
-        ).fetchall()
-        for row in rows:
-            meta_str = row[1]
-            if not meta_str:
-                continue
-            try:
-                meta = json.loads(meta_str)
-            except (json.JSONDecodeError, TypeError):
-                continue
-            aid = meta.get("agent_id")
-            if aid and aid != "default":
-                conn.execute(
-                    "UPDATE sessions SET agent_id = ? WHERE session_id = ?",
-                    (aid, row[0]),
-                )
-        conn.commit()
 
     def _migrate_agent_messages_table(self, conn: sqlite3.Connection) -> None:
         """为 agent_messages 表补充新增列（兼容旧库）。"""

--- a/sensenova_claw/adapters/storage/repository.py
+++ b/sensenova_claw/adapters/storage/repository.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 import json
 import sqlite3
+import threading
 import time
 from pathlib import Path
 from typing import Any
@@ -174,10 +175,28 @@ class Repository:
             db_path = str(resolve_sensenova_claw_home(config) / "data" / "sensenova-claw.db")
         self.db_path = Path(db_path).expanduser()
         self.db_path.parent.mkdir(parents=True, exist_ok=True)
+        self._local = threading.local()  # 线程本地连接存储
 
     def _conn(self) -> sqlite3.Connection:
-        conn = sqlite3.connect(self.db_path)
-        conn.row_factory = sqlite3.Row
+        """返回当前线程的 SQLite 连接（线程本地复用，首次创建时启用 WAL 模式）
+
+        注意：threading.local 已保证每个线程独占一个连接，连接永远不会跨线程共享，
+        因此不需要也不应该设置 check_same_thread=False（保持默认 True 以保留安全检查）。
+        """
+        conn = getattr(self._local, "conn", None)
+        # 检测连接是否已关闭（如 init() 调用 close() 后需重建）
+        if conn is not None:
+            try:
+                conn.execute("SELECT 1")
+            except Exception:
+                conn = None
+                self._local.conn = None
+        if conn is None:
+            conn = sqlite3.connect(self.db_path)  # 默认 check_same_thread=True，保留驱动安全检查
+            conn.row_factory = sqlite3.Row
+            conn.execute("PRAGMA journal_mode=WAL")   # 读写并发，减少锁竞争
+            conn.execute("PRAGMA synchronous=NORMAL")  # 降低 fsync 频率，性能与安全的平衡
+            self._local.conn = conn
         return conn
 
     async def init(self) -> None:

--- a/sensenova_claw/adapters/storage/repository.py
+++ b/sensenova_claw/adapters/storage/repository.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+import asyncio
 import json
 import sqlite3
 import threading
@@ -196,14 +197,15 @@ class Repository:
         return conn
 
     async def init(self) -> None:
+        await asyncio.to_thread(self._sync_init)
+
+    def _sync_init(self) -> None:
         conn = self._conn()
         conn.executescript(SCHEMA_SQL)
         conn.commit()
         self._migrate_sessions_table(conn)
         self._migrate_agent_messages_table(conn)
         self._migrate_cron_runs_table(conn)
-        conn.close()
-        self._local.conn = None  # 清除线程本地缓存，使下次 _conn() 重建连接
 
     async def create_session(self, session_id: str, meta: dict[str, Any] | None = None) -> None:
         now = time.time()
@@ -219,11 +221,12 @@ class Repository:
         self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def update_session_activity(self, session_id: str) -> None:
+        await asyncio.to_thread(self._sync_update_session_activity, session_id)
+
+    def _sync_update_session_activity(self, session_id: str) -> None:
         conn = self._conn()
         conn.execute("UPDATE sessions SET last_active = ? WHERE session_id = ?", (time.time(), session_id))
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def update_session_title(self, session_id: str, title: str) -> None:
         conn = self._conn()
@@ -306,6 +309,9 @@ class Repository:
         self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def log_event(self, event: EventEnvelope) -> None:
+        await asyncio.to_thread(self._sync_log_event, event)
+
+    def _sync_log_event(self, event: EventEnvelope) -> None:
         conn = self._conn()
         conn.execute(
             """INSERT INTO events (event_id, session_id, turn_id, event_type, timestamp, source, trace_id, payload_json)
@@ -322,8 +328,6 @@ class Repository:
             ),
         )
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def get_session_events(self, session_id: str) -> list[dict[str, Any]]:
         conn = self._conn()
@@ -564,6 +568,21 @@ class Repository:
         tool_name: str | None = None,
     ) -> None:
         """保存单条消息到 messages 表"""
+        await asyncio.to_thread(
+            self._sync_save_message,
+            session_id, turn_id, role, content, tool_calls, tool_call_id, tool_name,
+        )
+
+    def _sync_save_message(
+        self,
+        session_id: str,
+        turn_id: str,
+        role: str,
+        content: str | None,
+        tool_calls: str | None,
+        tool_call_id: str | None,
+        tool_name: str | None,
+    ) -> None:
         conn = self._conn()
         conn.execute(
             """INSERT INTO messages (session_id, turn_id, role, content, tool_calls, tool_call_id, tool_name, created_at)
@@ -571,8 +590,6 @@ class Repository:
             (session_id, turn_id, role, content, tool_calls, tool_call_id, tool_name, time.time()),
         )
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def get_session_messages(self, session_id: str) -> list[dict[str, Any]]:
         """获取会话的所有消息（按时间排序），返回 LLM 消息格式"""
@@ -615,14 +632,15 @@ class Repository:
 
     async def increment_message_count(self, session_id: str) -> None:
         """递增会话消息计数"""
+        await asyncio.to_thread(self._sync_increment_message_count, session_id)
+
+    def _sync_increment_message_count(self, session_id: str) -> None:
         conn = self._conn()
         conn.execute(
             "UPDATE sessions SET message_count = COALESCE(message_count, 0) + 1 WHERE session_id = ?",
             (session_id,),
         )
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def delete_session_cascade(self, session_id: str) -> None:
         """级联删除会话及关联的 turns, messages, events"""

--- a/sensenova_claw/adapters/storage/repository.py
+++ b/sensenova_claw/adapters/storage/repository.py
@@ -182,6 +182,9 @@ class Repository:
 
         注意：threading.local 已保证每个线程独占一个连接，连接永远不会跨线程共享，
         因此不需要也不应该设置 check_same_thread=False（保持默认 True 以保留安全检查）。
+
+        TODO: Task 2-6 完成后，所有 async 方法将迁移至 asyncio.to_thread + _sync_* 模式，
+        届时业务方法中的 conn.close() + self._local.conn = None 均可删除（连接将持久复用）。
         """
         conn = getattr(self._local, "conn", None)
         if conn is None:

--- a/sensenova_claw/adapters/storage/repository.py
+++ b/sensenova_claw/adapters/storage/repository.py
@@ -275,24 +275,26 @@ class Repository:
         return sessions[:limit]
 
     async def create_turn(self, turn_id: str, session_id: str, user_input: str) -> None:
+        await asyncio.to_thread(self._sync_create_turn, turn_id, session_id, user_input)
+
+    def _sync_create_turn(self, turn_id: str, session_id: str, user_input: str) -> None:
         conn = self._conn()
         conn.execute(
             "INSERT INTO turns (turn_id, session_id, status, started_at, user_input) VALUES (?, ?, ?, ?, ?)",
             (turn_id, session_id, "started", time.time(), user_input),
         )
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def complete_turn(self, turn_id: str, agent_response: str) -> None:
+        await asyncio.to_thread(self._sync_complete_turn, turn_id, agent_response)
+
+    def _sync_complete_turn(self, turn_id: str, agent_response: str) -> None:
         conn = self._conn()
         conn.execute(
             "UPDATE turns SET status = ?, ended_at = ?, agent_response = ? WHERE turn_id = ?",
             ("completed", time.time(), agent_response, turn_id),
         )
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def update_turn_status(
         self,
@@ -301,14 +303,15 @@ class Repository:
         agent_response: str | None = None,
     ) -> None:
         """更新 turn 状态，必要时补充结束时间与最终输出。"""
+        await asyncio.to_thread(self._sync_update_turn_status, turn_id, status, agent_response)
+
+    def _sync_update_turn_status(self, turn_id: str, status: str, agent_response: str | None) -> None:
         conn = self._conn()
         conn.execute(
             "UPDATE turns SET status = ?, ended_at = ?, agent_response = ? WHERE turn_id = ?",
             (status, time.time(), agent_response, turn_id),
         )
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def log_event(self, event: EventEnvelope) -> None:
         await asyncio.to_thread(self._sync_log_event, event)
@@ -332,10 +335,11 @@ class Repository:
         conn.commit()
 
     async def get_session_events(self, session_id: str) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(self._sync_get_session_events, session_id)
+
+    def _sync_get_session_events(self, session_id: str) -> list[dict[str, Any]]:
         conn = self._conn()
         rows = conn.execute("SELECT * FROM events WHERE session_id = ? ORDER BY timestamp", (session_id,)).fetchall()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     def _parse_payload_json(self, raw: str | bytes | None) -> dict[str, Any]:
@@ -458,13 +462,14 @@ class Repository:
         return pending
 
     async def get_session_turns(self, session_id: str) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(self._sync_get_session_turns, session_id)
+
+    def _sync_get_session_turns(self, session_id: str) -> list[dict[str, Any]]:
         conn = self._conn()
         rows = conn.execute(
             "SELECT * FROM turns WHERE session_id = ? ORDER BY started_at",
             (session_id,),
         ).fetchall()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     # ---------- Sessions 表迁移 ----------
@@ -596,13 +601,14 @@ class Repository:
 
     async def get_session_messages(self, session_id: str) -> list[dict[str, Any]]:
         """获取会话的所有消息（按时间排序），返回 LLM 消息格式"""
+        return await asyncio.to_thread(self._sync_get_session_messages, session_id)
+
+    def _sync_get_session_messages(self, session_id: str) -> list[dict[str, Any]]:
         conn = self._conn()
         rows = conn.execute(
             "SELECT role, content, tool_calls, tool_call_id, tool_name FROM messages WHERE session_id = ? ORDER BY created_at",
             (session_id,),
         ).fetchall()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         messages: list[dict[str, Any]] = []
         for row in rows:
             msg: dict[str, Any] = {"role": row[0]}

--- a/sensenova_claw/adapters/storage/repository.py
+++ b/sensenova_claw/adapters/storage/repository.py
@@ -208,6 +208,9 @@ class Repository:
         self._migrate_cron_runs_table(conn)
 
     async def create_session(self, session_id: str, meta: dict[str, Any] | None = None) -> None:
+        await asyncio.to_thread(self._sync_create_session, session_id, meta)
+
+    def _sync_create_session(self, session_id: str, meta: dict[str, Any] | None) -> None:
         now = time.time()
         meta = meta or {}
         agent_id = meta.get("agent_id", "default")
@@ -217,8 +220,6 @@ class Repository:
             (session_id, now, now, json.dumps(meta, ensure_ascii=False), agent_id),
         )
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def update_session_activity(self, session_id: str) -> None:
         await asyncio.to_thread(self._sync_update_session_activity, session_id)
@@ -229,16 +230,16 @@ class Repository:
         conn.commit()
 
     async def update_session_title(self, session_id: str, title: str) -> None:
+        await asyncio.to_thread(self._sync_update_session_title, session_id, title)
+
+    def _sync_update_session_title(self, session_id: str, title: str) -> None:
         conn = self._conn()
-        # 获取当前 meta
         row = conn.execute("SELECT meta FROM sessions WHERE session_id = ?", (session_id,)).fetchone()
         if row:
             meta = json.loads(row[0]) if row[0] else {}
             meta["title"] = title
             conn.execute("UPDATE sessions SET meta = ? WHERE session_id = ?", (json.dumps(meta, ensure_ascii=False), session_id))
             conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def list_sessions(
         self,
@@ -246,6 +247,9 @@ class Repository:
         *,
         include_hidden: bool = False,
     ) -> list[dict[str, Any]]:
+        return await asyncio.to_thread(self._sync_list_sessions, limit, include_hidden)
+
+    def _sync_list_sessions(self, limit: int, include_hidden: bool) -> list[dict[str, Any]]:
         conn = self._conn()
         rows = conn.execute(
             """
@@ -265,8 +269,6 @@ class Repository:
             ORDER BY s.last_active DESC
             """,
         ).fetchall()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         sessions = [dict(row) for row in rows]
         if not include_hidden:
             sessions = [row for row in sessions if not self._is_hidden_session(row.get("meta"))]
@@ -547,10 +549,11 @@ class Repository:
 
     async def get_session_meta(self, session_id: str) -> dict[str, Any] | None:
         """获取会话的 meta 信息（含 agent_id 等）"""
+        return await asyncio.to_thread(self._sync_get_session_meta, session_id)
+
+    def _sync_get_session_meta(self, session_id: str) -> dict[str, Any] | None:
         conn = self._conn()
         row = conn.execute("SELECT meta FROM sessions WHERE session_id = ?", (session_id,)).fetchone()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         if not row or not row[0]:
             return None
         return json.loads(row[0])
@@ -621,14 +624,15 @@ class Repository:
         model: str | None = None,
     ) -> None:
         """更新会话的 channel 和 model 信息"""
+        await asyncio.to_thread(self._sync_update_session_info, session_id, channel, model)
+
+    def _sync_update_session_info(self, session_id: str, channel: str | None, model: str | None) -> None:
         conn = self._conn()
         if channel is not None:
             conn.execute("UPDATE sessions SET channel = ? WHERE session_id = ?", (channel, session_id))
         if model is not None:
             conn.execute("UPDATE sessions SET model = ? WHERE session_id = ?", (model, session_id))
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def increment_message_count(self, session_id: str) -> None:
         """递增会话消息计数"""

--- a/sensenova_claw/adapters/storage/repository.py
+++ b/sensenova_claw/adapters/storage/repository.py
@@ -654,6 +654,9 @@ class Repository:
 
     async def delete_session_cascade(self, session_id: str) -> None:
         """级联删除会话及关联的 turns, messages, events"""
+        await asyncio.to_thread(self._sync_delete_session_cascade, session_id)
+
+    def _sync_delete_session_cascade(self, session_id: str) -> None:
         conn = self._conn()
         conn.execute(
             "DELETE FROM agent_messages WHERE parent_session_id = ? OR child_session_id = ?",
@@ -664,8 +667,6 @@ class Repository:
         conn.execute("DELETE FROM turns WHERE session_id = ?", (session_id,))
         conn.execute("DELETE FROM sessions WHERE session_id = ?", (session_id,))
         conn.commit()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     # ---------- Agent Messages 表操作 ----------
 
@@ -766,36 +767,41 @@ class Repository:
 
     async def prune_sessions(self, max_age_days: int = 30) -> int:
         """删除超期未活跃的会话及关联数据，返回删除数量"""
+        return await asyncio.to_thread(self._sync_prune_sessions, max_age_days)
+
+    def _sync_prune_sessions(self, max_age_days: int) -> int:
         cutoff = time.time() - max_age_days * 86400
         conn = self._conn()
+        # 注意：必须先 fetchall() 拿到全部结果，再进入循环执行 DELETE。
+        # 如果使用游标懒迭代，后续的 DELETE + commit 会使游标失效。
         rows = conn.execute(
             "SELECT session_id FROM sessions WHERE last_active < ?", (cutoff,)
         ).fetchall()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         count = 0
         for row in rows:
-            await self.delete_session_cascade(row[0])
+            # _sync_delete_session_cascade 与本方法在同一线程执行（threading.local 保证），
+            # 复用同一个 conn 对象，串行调用安全。
+            self._sync_delete_session_cascade(row[0])
             count += 1
         return count
 
     async def cap_sessions(self, max_count: int = 500) -> int:
         """限制会话总数，淘汰最旧的，返回删除数量"""
+        return await asyncio.to_thread(self._sync_cap_sessions, max_count)
+
+    def _sync_cap_sessions(self, max_count: int) -> int:
         conn = self._conn()
         total = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
         if total <= max_count:
-            conn.close()
-            self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
             return 0
         overflow = total - max_count
+        # 同 _sync_prune_sessions：先 fetchall() 后再循环 DELETE
         rows = conn.execute(
             "SELECT session_id FROM sessions ORDER BY last_active ASC LIMIT ?", (overflow,)
         ).fetchall()
-        conn.close()
-        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         count = 0
         for row in rows:
-            await self.delete_session_cascade(row[0])
+            self._sync_delete_session_cascade(row[0])
             count += 1
         return count
 

--- a/sensenova_claw/adapters/storage/repository.py
+++ b/sensenova_claw/adapters/storage/repository.py
@@ -184,13 +184,6 @@ class Repository:
         因此不需要也不应该设置 check_same_thread=False（保持默认 True 以保留安全检查）。
         """
         conn = getattr(self._local, "conn", None)
-        # 检测连接是否已关闭（如 init() 调用 close() 后需重建）
-        if conn is not None:
-            try:
-                conn.execute("SELECT 1")
-            except Exception:
-                conn = None
-                self._local.conn = None
         if conn is None:
             conn = sqlite3.connect(self.db_path)  # 默认 check_same_thread=True，保留驱动安全检查
             conn.row_factory = sqlite3.Row
@@ -207,6 +200,7 @@ class Repository:
         self._migrate_agent_messages_table(conn)
         self._migrate_cron_runs_table(conn)
         conn.close()
+        self._local.conn = None  # 清除线程本地缓存，使下次 _conn() 重建连接
 
     async def create_session(self, session_id: str, meta: dict[str, Any] | None = None) -> None:
         now = time.time()
@@ -219,12 +213,14 @@ class Repository:
         )
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def update_session_activity(self, session_id: str) -> None:
         conn = self._conn()
         conn.execute("UPDATE sessions SET last_active = ? WHERE session_id = ?", (time.time(), session_id))
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def update_session_title(self, session_id: str, title: str) -> None:
         conn = self._conn()
@@ -236,6 +232,7 @@ class Repository:
             conn.execute("UPDATE sessions SET meta = ? WHERE session_id = ?", (json.dumps(meta, ensure_ascii=False), session_id))
             conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def list_sessions(
         self,
@@ -263,6 +260,7 @@ class Repository:
             """,
         ).fetchall()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         sessions = [dict(row) for row in rows]
         if not include_hidden:
             sessions = [row for row in sessions if not self._is_hidden_session(row.get("meta"))]
@@ -276,6 +274,7 @@ class Repository:
         )
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def complete_turn(self, turn_id: str, agent_response: str) -> None:
         conn = self._conn()
@@ -285,6 +284,7 @@ class Repository:
         )
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def update_turn_status(
         self,
@@ -300,6 +300,7 @@ class Repository:
         )
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def log_event(self, event: EventEnvelope) -> None:
         conn = self._conn()
@@ -319,11 +320,13 @@ class Repository:
         )
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def get_session_events(self, session_id: str) -> list[dict[str, Any]]:
         conn = self._conn()
         rows = conn.execute("SELECT * FROM events WHERE session_id = ? ORDER BY timestamp", (session_id,)).fetchall()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     def _parse_payload_json(self, raw: str | bytes | None) -> dict[str, Any]:
@@ -442,6 +445,7 @@ class Repository:
                 break
 
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return pending
 
     async def get_session_turns(self, session_id: str) -> list[dict[str, Any]]:
@@ -451,6 +455,7 @@ class Repository:
             (session_id,),
         ).fetchall()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     # ---------- Sessions 表迁移 ----------
@@ -538,6 +543,7 @@ class Repository:
         conn = self._conn()
         row = conn.execute("SELECT meta FROM sessions WHERE session_id = ?", (session_id,)).fetchone()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         if not row or not row[0]:
             return None
         return json.loads(row[0])
@@ -563,6 +569,7 @@ class Repository:
         )
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def get_session_messages(self, session_id: str) -> list[dict[str, Any]]:
         """获取会话的所有消息（按时间排序），返回 LLM 消息格式"""
@@ -572,6 +579,7 @@ class Repository:
             (session_id,),
         ).fetchall()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         messages: list[dict[str, Any]] = []
         for row in rows:
             msg: dict[str, Any] = {"role": row[0]}
@@ -600,6 +608,7 @@ class Repository:
             conn.execute("UPDATE sessions SET model = ? WHERE session_id = ?", (model, session_id))
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def increment_message_count(self, session_id: str) -> None:
         """递增会话消息计数"""
@@ -610,6 +619,7 @@ class Repository:
         )
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def delete_session_cascade(self, session_id: str) -> None:
         """级联删除会话及关联的 turns, messages, events"""
@@ -624,6 +634,7 @@ class Repository:
         conn.execute("DELETE FROM sessions WHERE session_id = ?", (session_id,))
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     # ---------- Agent Messages 表操作 ----------
 
@@ -663,6 +674,7 @@ class Repository:
         )
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def update_message_record(self, record: MessageRecord) -> None:
         """更新 Agent-to-Agent 消息记录。"""
@@ -676,6 +688,7 @@ class Repository:
             (record_id,),
         ).fetchone()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         if not row:
             return None
         return MessageRecord.from_mapping(dict(row))
@@ -696,6 +709,7 @@ class Repository:
             (child_session_id,),
         ).fetchone()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         if not row:
             return None
         return MessageRecord.from_mapping(dict(row))
@@ -716,6 +730,7 @@ class Repository:
             (parent_session_id,),
         ).fetchall()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [MessageRecord.from_mapping(dict(row)) for row in rows]
 
     async def prune_sessions(self, max_age_days: int = 30) -> int:
@@ -726,6 +741,7 @@ class Repository:
             "SELECT session_id FROM sessions WHERE last_active < ?", (cutoff,)
         ).fetchall()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         count = 0
         for row in rows:
             await self.delete_session_cascade(row[0])
@@ -738,12 +754,14 @@ class Repository:
         total = conn.execute("SELECT COUNT(*) FROM sessions").fetchone()[0]
         if total <= max_count:
             conn.close()
+            self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
             return 0
         overflow = total - max_count
         rows = conn.execute(
             "SELECT session_id FROM sessions ORDER BY last_active ASC LIMIT ?", (overflow,)
         ).fetchall()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         count = 0
         for row in rows:
             await self.delete_session_cascade(row[0])
@@ -775,12 +793,14 @@ class Repository:
         )
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def get_cron_job(self, job_id: str) -> dict[str, Any] | None:
         """按 ID 查询单条 cron job"""
         conn = self._conn()
         row = conn.execute("SELECT * FROM cron_jobs WHERE id = ?", (job_id,)).fetchone()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return dict(row) if row else None
 
     async def list_cron_jobs(self, enabled_only: bool = False) -> list[dict[str, Any]]:
@@ -791,6 +811,7 @@ class Repository:
         else:
             rows = conn.execute("SELECT * FROM cron_jobs ORDER BY created_at_ms").fetchall()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     async def update_cron_job(self, job_id: str, updates: dict[str, Any]) -> None:
@@ -803,6 +824,7 @@ class Repository:
         conn.execute(f"UPDATE cron_jobs SET {', '.join(set_parts)} WHERE id = ?", values)
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def delete_cron_job(self, job_id: str, *, keep_runs: bool = False) -> None:
         """删除 cron job。keep_runs=True 时保留 runs 历史（用于自动删除场景）。"""
@@ -812,6 +834,7 @@ class Repository:
         conn.execute("DELETE FROM cron_jobs WHERE id = ?", (job_id,))
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def get_runnable_cron_jobs(self, now_ms: int) -> list[dict[str, Any]]:
         """返回到期且未在执行中的 enabled jobs"""
@@ -821,6 +844,7 @@ class Repository:
             (now_ms,),
         ).fetchall()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     async def update_cron_job_state(self, job_id: str, state_updates: dict[str, Any]) -> None:
@@ -833,6 +857,7 @@ class Repository:
         conn.execute("UPDATE cron_jobs SET running_at_ms = NULL WHERE running_at_ms IS NOT NULL")
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     # ---------- Cron Runs 表操作 ----------
 
@@ -855,6 +880,7 @@ class Repository:
         run_id = cursor.lastrowid
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return run_id
 
     async def update_cron_run(self, run_id: int, updates: dict[str, Any]) -> None:
@@ -867,6 +893,7 @@ class Repository:
         conn.execute(f"UPDATE cron_runs SET {', '.join(set_parts)} WHERE id = ?", values)
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def list_cron_runs(self, job_id: str, limit: int = 50) -> list[dict[str, Any]]:
         """按 started_at_ms 倒序列出 job 运行历史。"""
@@ -876,6 +903,7 @@ class Repository:
             (job_id, limit),
         ).fetchall()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     async def list_all_cron_runs(self, limit: int = 50, status: str | None = None) -> list[dict[str, Any]]:
@@ -894,6 +922,7 @@ class Repository:
         params.append(limit)
         rows = conn.execute(sql, params).fetchall()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     # ---------- Proactive Jobs 表操作 ----------
@@ -917,12 +946,14 @@ class Repository:
         )
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def get_proactive_job(self, job_id: str) -> dict[str, Any] | None:
         """按 ID 查询单条 proactive job"""
         conn = self._conn()
         row = conn.execute("SELECT * FROM proactive_jobs WHERE id = ?", (job_id,)).fetchone()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return dict(row) if row else None
 
     async def list_proactive_jobs(self, enabled_only: bool = False) -> list[dict[str, Any]]:
@@ -935,6 +966,7 @@ class Repository:
         else:
             rows = conn.execute("SELECT * FROM proactive_jobs ORDER BY created_at_ms").fetchall()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     async def update_proactive_job(self, job_id: str, updates: dict[str, Any]) -> None:
@@ -947,6 +979,7 @@ class Repository:
         conn.execute(f"UPDATE proactive_jobs SET {', '.join(set_parts)} WHERE id = ?", values)
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def delete_proactive_job(self, job_id: str) -> None:
         """删除 proactive job 及其 runs"""
@@ -955,6 +988,7 @@ class Repository:
         conn.execute("DELETE FROM proactive_jobs WHERE id = ?", (job_id,))
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     # ---------- Proactive Runs 表操作 ----------
 
@@ -974,6 +1008,7 @@ class Repository:
         )
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def update_proactive_run(self, run_id: str, updates: dict[str, Any]) -> None:
         """更新 proactive_runs 记录"""
@@ -985,6 +1020,7 @@ class Repository:
         conn.execute(f"UPDATE proactive_runs SET {', '.join(set_parts)} WHERE id = ?", values)
         conn.commit()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
 
     async def list_proactive_runs(self, job_id: str, limit: int = 50) -> list[dict[str, Any]]:
         """按 started_at_ms 倒序列出 job 运行历史"""
@@ -994,6 +1030,7 @@ class Repository:
             (job_id, limit),
         ).fetchall()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return [dict(row) for row in rows]
 
     async def get_proactive_run(self, run_id: str) -> dict[str, Any] | None:
@@ -1001,4 +1038,5 @@ class Repository:
         conn = self._conn()
         row = conn.execute("SELECT * FROM proactive_runs WHERE id = ?", (run_id,)).fetchone()
         conn.close()
+        self._local.conn = None  # 关闭后清除缓存，避免下次 _conn() 返回已关闭连接
         return dict(row) if row else None

--- a/sensenova_claw/app/gateway/main.py
+++ b/sensenova_claw/app/gateway/main.py
@@ -461,44 +461,6 @@ async def health_check() -> dict:
     return {"status": "healthy", "timestamp": time.time(), "version": "0.1.0"}
 
 
-@app.get("/api/sessions")
-async def list_sessions():
-    """获取会话列表"""
-    sessions = await app.state.services.gateway.list_sessions()
-    return JSONResponse(content={"sessions": sessions})
-
-
-@app.delete("/api/sessions/{session_id}")
-async def delete_session(session_id: str):
-    """删除会话及关联数据"""
-    try:
-        await app.state.services.gateway.delete_session(session_id)
-        return JSONResponse(content={"ok": True, "session_id": session_id})
-    except Exception as e:
-        return JSONResponse(status_code=500, content={"ok": False, "error": str(e)})
-
-
-@app.get("/api/sessions/{session_id}/turns")
-async def get_session_turns(session_id: str):
-    """获取会话的所有轮次"""
-    turns = await app.state.services.gateway.get_session_turns(session_id)
-    return JSONResponse(content={"turns": turns})
-
-
-@app.get("/api/sessions/{session_id}/events")
-async def get_session_events(session_id: str):
-    """获取会话的所有事件"""
-    events = await app.state.services.gateway.get_session_events(session_id)
-    return JSONResponse(content={"events": events})
-
-
-@app.get("/api/sessions/{session_id}/messages")
-async def list_session_messages(session_id: str):
-    """获取会话的所有消息"""
-    messages = await app.state.services.gateway.get_messages(session_id)
-    return JSONResponse(content={"messages": messages})
-
-
 @app.websocket("/ws")
 async def websocket_endpoint(websocket: WebSocket):
     """WebSocket 端点 — 委托给 WebSocketChannel 处理"""

--- a/sensenova_claw/app/web/components/chat/ChatInput.tsx
+++ b/sensenova_claw/app/web/components/chat/ChatInput.tsx
@@ -142,7 +142,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
     },
   }), [resizeTextarea]);
 
-  const { showMenu, handleSelect: handleSlashSelect, handleSubmit: handleSlashSubmitHook } = useSlashCommand(
+  const { showMenu, skills, handleSelect: handleSlashSelect, handleSubmit: handleSlashSubmitHook } = useSlashCommand(
     inputValue, setInputValue, handleSkillInvoke,
   );
 
@@ -291,7 +291,7 @@ export const ChatInput = forwardRef<ChatInputHandle, ChatInputProps>(function Ch
 
           <div className="flex-1">
             <UploadProgress items={uploadItems} />
-            <SlashCommandMenu inputValue={inputValue} onSelect={handleSlashSelect} visible={showMenu} />
+            <SlashCommandMenu inputValue={inputValue} skills={skills} onSelect={handleSlashSelect} visible={showMenu} />
             <textarea
               data-testid="chat-input"
               ref={textareaRef}

--- a/sensenova_claw/app/web/components/chat/SlashCommandMenu.tsx
+++ b/sensenova_claw/app/web/components/chat/SlashCommandMenu.tsx
@@ -2,42 +2,27 @@
 
 import { useState, useEffect, useRef } from 'react';
 import { authFetch, API_BASE } from '@/lib/authFetch';
-
-interface SkillItem {
-  name: string;
-  description: string;
-}
+import {
+  filterSlashCommandSkills,
+  getSlashCommandQuery,
+  resolveSlashCommandSubmission,
+  type SlashCommandSkillItem,
+} from './slashCommand';
 
 interface SlashCommandMenuProps {
   inputValue: string;
+  skills: SlashCommandSkillItem[];
   onSelect: (skillName: string) => void;
   visible: boolean;
 }
 
-export function SlashCommandMenu({ inputValue, onSelect, visible }: SlashCommandMenuProps) {
-  const [skills, setSkills] = useState<SkillItem[]>([]);
+export function SlashCommandMenu({ inputValue, skills, onSelect, visible }: SlashCommandMenuProps) {
   const [selectedIndex, setSelectedIndex] = useState(0);
   const menuRef = useRef<HTMLDivElement>(null);
 
-  // 加载已启用的 skills
-  useEffect(() => {
-    authFetch(`${API_BASE}/api/skills`)
-      .then(r => r.json())
-      .then((data: any[]) => {
-        setSkills(
-          data
-            .filter(s => s.enabled)
-            .map(s => ({ name: s.name, description: s.description }))
-        );
-      })
-      .catch(() => setSkills([]));
-  }, []);
-
   // 过滤
-  const query = inputValue.startsWith('/') ? inputValue.slice(1).toLowerCase() : '';
-  const filtered = skills.filter(s =>
-    s.name.toLowerCase().includes(query) || s.description.toLowerCase().includes(query)
-  );
+  const query = getSlashCommandQuery(inputValue);
+  const filtered = filterSlashCommandSkills(inputValue, skills);
 
   // 重置选中
   useEffect(() => { setSelectedIndex(0); }, [query]);
@@ -75,6 +60,25 @@ export function useSlashCommand(
   setInputValue: (v: string) => void,
   onInvoke: (skillName: string, args: string) => void,
 ) {
+  const [skills, setSkills] = useState<SlashCommandSkillItem[]>([]);
+
+  useEffect(() => {
+    authFetch(`${API_BASE}/api/skills`)
+      .then(r => r.json())
+      .then((data: Array<{ name?: string; description?: string; enabled?: boolean }>) => {
+        setSkills(
+          data
+            .filter((skill) => skill.enabled)
+            .map((skill) => ({
+              name: String(skill.name || ''),
+              description: String(skill.description || ''),
+            }))
+            .filter((skill) => skill.name),
+        );
+      })
+      .catch(() => setSkills([]));
+  }, []);
+
   const showMenu = inputValue.startsWith('/') && !inputValue.includes(' ');
 
   const handleSelect = (skillName: string) => {
@@ -82,18 +86,16 @@ export function useSlashCommand(
   };
 
   const handleSubmit = (text: string): boolean => {
-    // 检查是否是斜杠命令
-    if (text.startsWith('/')) {
-      const parts = text.slice(1).split(/\s+/, 2);
-      const skillName = parts[0];
-      const args = text.slice(1 + skillName.length).trim();
-      if (skillName) {
-        onInvoke(skillName, args);
-        return true; // 已处理
-      }
+    const submission = resolveSlashCommandSubmission(
+      text,
+      skills.map((skill) => skill.name),
+    );
+    if (submission.handled && submission.skillName) {
+      onInvoke(submission.skillName, submission.args);
+      return true;
     }
-    return false; // 非斜杠命令，走正常消息发送
+    return false;
   };
 
-  return { showMenu, handleSelect, handleSubmit };
+  return { showMenu, skills, handleSelect, handleSubmit };
 }

--- a/sensenova_claw/app/web/components/chat/slashCommand.ts
+++ b/sensenova_claw/app/web/components/chat/slashCommand.ts
@@ -1,0 +1,56 @@
+export interface SlashCommandSkillItem {
+  name: string;
+  description: string;
+}
+
+export interface SlashCommandSubmissionResult {
+  handled: boolean;
+  skillName: string | null;
+  args: string;
+}
+
+export function getSlashCommandQuery(inputValue: string): string {
+  return inputValue.startsWith('/') ? inputValue.slice(1).toLowerCase() : '';
+}
+
+export function filterSlashCommandSkills(
+  inputValue: string,
+  skills: SlashCommandSkillItem[],
+): SlashCommandSkillItem[] {
+  const query = getSlashCommandQuery(inputValue);
+  if (!query) {
+    return skills;
+  }
+  return skills.filter((skill) =>
+    skill.name.toLowerCase().includes(query) || skill.description.toLowerCase().includes(query),
+  );
+}
+
+export function resolveSlashCommandSubmission(
+  text: string,
+  enabledSkillNames: string[],
+): SlashCommandSubmissionResult {
+  if (!text.startsWith('/')) {
+    return { handled: false, skillName: null, args: '' };
+  }
+
+  const parts = text.slice(1).split(/\s+/, 2);
+  const rawSkillName = parts[0]?.trim() || '';
+  if (!rawSkillName) {
+    return { handled: false, skillName: null, args: '' };
+  }
+
+  const normalizedSkillName = rawSkillName.toLowerCase();
+  const matchedSkillName = enabledSkillNames.find(
+    (skillName) => skillName.toLowerCase() === normalizedSkillName,
+  );
+  if (!matchedSkillName) {
+    return { handled: false, skillName: null, args: '' };
+  }
+
+  return {
+    handled: true,
+    skillName: matchedSkillName,
+    args: text.slice(1 + rawSkillName.length).trim(),
+  };
+}

--- a/sensenova_claw/app/web/contexts/ws/MessageContext.tsx
+++ b/sensenova_claw/app/web/contexts/ws/MessageContext.tsx
@@ -536,14 +536,41 @@ export function MessageProvider({ children }: { children: React.ReactNode }) {
   }, [getCurrentSessionAgentId, resetTurnTracking, startNewChat, wsSend, sessionIdRef, emptySessionIdRef, markFrontendCreate]);
 
   const handleSkillInvoke = useCallback(async (skillName: string, args: string) => {
-    if (!sessionIdRef.current) return;
-    await authFetch(`${API_BASE}/api/sessions/${sessionIdRef.current}/skill-invoke`, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ skill_name: skillName, arguments: args }),
-    });
-    setIsTyping(true);
-  }, [sessionIdRef]);
+    if (!sessionIdRef.current) {
+      pushNotification({
+        title: '命令执行失败',
+        body: '请先发送一条普通消息创建会话，再执行 / 命令',
+        level: 'error',
+        source: 'skill',
+      });
+      return;
+    }
+    try {
+      const resp = await authFetch(`${API_BASE}/api/sessions/${sessionIdRef.current}/skill-invoke`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ skill_name: skillName, arguments: args }),
+      });
+      if (!resp.ok) {
+        const errData = await resp.json().catch(() => ({ detail: `HTTP ${resp.status}` }));
+        pushNotification({
+          title: '命令执行失败',
+          body: errData.detail || `未知错误 (${resp.status})`,
+          level: 'error',
+          source: 'skill',
+        });
+        return;
+      }
+      setIsTyping(true);
+    } catch (err) {
+      pushNotification({
+        title: '命令执行失败',
+        body: '网络错误，请稍后重试',
+        level: 'error',
+        source: 'skill',
+      });
+    }
+  }, [sessionIdRef, pushNotification]);
 
   const cancelTurn = useCallback(() => {
     if (!sessionIdRef.current) return;

--- a/sensenova_claw/app/web/e2e/chat-slash-command-fallback.spec.ts
+++ b/sensenova_claw/app/web/e2e/chat-slash-command-fallback.spec.ts
@@ -1,0 +1,178 @@
+import fs from 'node:fs';
+import os from 'node:os';
+import path from 'node:path';
+
+import { expect, test } from '@playwright/test';
+
+function readCurrentToken(): string {
+  try {
+    return fs.readFileSync(path.join(os.homedir(), '.sensenova-claw', 'token'), 'utf-8').trim();
+  } catch {
+    return 'test-token';
+  }
+}
+
+test('未匹配的 / 命令应作为普通消息发送', async ({ page }) => {
+  const token = readCurrentToken();
+  await page.context().addCookies([{
+    name: 'sensenova_claw_token',
+    value: token,
+    domain: 'localhost',
+    path: '/',
+  }]);
+
+  await page.addInitScript(() => {
+    const nativeFetch = window.fetch.bind(window);
+    const sentMessages: Array<Record<string, unknown>> = [];
+    const NativeWebSocket = window.WebSocket;
+
+    window.fetch = async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input instanceof URL ? input.toString() : input.url;
+
+      if (url.includes('/api/auth/status')) {
+        return new Response(JSON.stringify({ authenticated: true }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (url.endsWith('/api/skills')) {
+        return new Response(JSON.stringify([
+          { name: 'brainstorming', description: '头脑风暴', enabled: true },
+        ]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (url.includes('/api/agents')) {
+        return new Response(JSON.stringify([
+          { id: 'default', name: 'Default Agent', description: '默认智能体', model: 'mock-model' },
+        ]), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (url.endsWith('/api/sessions')) {
+        return new Response(JSON.stringify({ sessions: [] }), {
+          status: 200,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      if (url.includes('/skill-invoke')) {
+        return new Response(JSON.stringify({ detail: '不应该触发 skill-invoke' }), {
+          status: 500,
+          headers: { 'Content-Type': 'application/json' },
+        });
+      }
+
+      return nativeFetch(input, init);
+    };
+
+    class FakeWebSocket {
+      static CONNECTING = 0;
+      static OPEN = 1;
+      static CLOSING = 2;
+      static CLOSED = 3;
+
+      readyState = FakeWebSocket.CONNECTING;
+      onopen: ((event: Event) => void) | null = null;
+      onclose: ((event: CloseEvent) => void) | null = null;
+      onerror: ((event: Event) => void) | null = null;
+      onmessage: ((event: MessageEvent) => void) | null = null;
+
+      constructor(_url: string) {
+        setTimeout(() => {
+          this.readyState = FakeWebSocket.OPEN;
+          this.onopen?.(new Event('open'));
+        }, 20);
+      }
+
+      send(data: string) {
+        const parsed = JSON.parse(data) as Record<string, unknown>;
+        sentMessages.push(parsed);
+        (window as typeof window & {
+          __wsSentMessages?: Array<Record<string, unknown>>;
+        }).__wsSentMessages = sentMessages;
+
+        if (parsed.type === 'create_session') {
+          setTimeout(() => {
+            this.onmessage?.(new MessageEvent('message', {
+              data: JSON.stringify({
+                type: 'session_created',
+                session_id: 'sess_slash_fallback',
+                payload: {},
+              }),
+            }));
+          }, 10);
+        }
+      }
+
+      close() {
+        this.readyState = FakeWebSocket.CLOSED;
+      }
+
+      addEventListener() {}
+
+      removeEventListener() {}
+    }
+
+    function MockWebSocket(url: string | URL, protocols?: string | string[]) {
+      const urlString = String(url);
+      if (urlString.includes('localhost:8000/ws')) {
+        return new FakeWebSocket(urlString);
+      }
+      return new NativeWebSocket(url, protocols);
+    }
+
+    Object.assign(MockWebSocket, {
+      CONNECTING: FakeWebSocket.CONNECTING,
+      OPEN: FakeWebSocket.OPEN,
+      CLOSING: FakeWebSocket.CLOSING,
+      CLOSED: FakeWebSocket.CLOSED,
+    });
+
+    Object.defineProperty(window, 'WebSocket', {
+      configurable: true,
+      writable: true,
+      value: MockWebSocket,
+    });
+  });
+
+  await page.goto('about:blank');
+  await page.goto('/');
+
+  const input = page.getByTestId('chat-input');
+  await expect(input).toBeVisible({ timeout: 5000 });
+
+  const prompt = '/does-not-exist 帮我做个总结';
+  await input.fill(prompt);
+  await page.getByTestId('send-button').click();
+
+  await expect.poll(async () => {
+    return page.evaluate(() => {
+      const sentMessages = (window as typeof window & {
+        __wsSentMessages?: Array<Record<string, unknown>>;
+      }).__wsSentMessages ?? [];
+      return sentMessages.some((message) => message.type === 'create_session');
+    });
+  }).toBe(true);
+
+  await expect.poll(async () => {
+    return page.evaluate((expectedPrompt) => {
+      const sentMessages = (window as typeof window & {
+        __wsSentMessages?: Array<Record<string, unknown>>;
+      }).__wsSentMessages ?? [];
+      return sentMessages.some(
+        (message) =>
+          message.type === 'user_input' &&
+          message.session_id === 'sess_slash_fallback' &&
+          typeof message.payload === 'object' &&
+          message.payload !== null &&
+          (message.payload as { content?: string }).content === expectedPrompt,
+      );
+    }, prompt);
+  }).toBe(true);
+});

--- a/sensenova_claw/app/web/tests/slash-command.test.ts
+++ b/sensenova_claw/app/web/tests/slash-command.test.ts
@@ -1,0 +1,24 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import { resolveSlashCommandSubmission } from '../components/chat/slashCommand.ts';
+
+test('未知 slash 命令不应被当作已处理命令', () => {
+  const result = resolveSlashCommandSubmission('/does-not-exist 帮我做个总结', ['brainstorming']);
+
+  assert.deepEqual(result, {
+    handled: false,
+    skillName: null,
+    args: '',
+  });
+});
+
+test('已存在的 slash 命令应返回 skill 名称和参数', () => {
+  const result = resolveSlashCommandSubmission('/brainstorming 帮我整理需求', ['brainstorming']);
+
+  assert.deepEqual(result, {
+    handled: true,
+    skillName: 'brainstorming',
+    args: '帮我整理需求',
+  });
+});

--- a/tests/unit/test_session_persistence.py
+++ b/tests/unit/test_session_persistence.py
@@ -188,3 +188,68 @@ async def test_load_session_history_from_state_store(repo):
     # 第二次加载：从内存缓存
     history2 = await store.load_session_history(session_id, repo)
     assert history2 is history  # 同一个对象引用
+
+
+@pytest.mark.asyncio
+async def test_log_event_not_blocking_event_loop(repo):
+    """验证 log_event 在线程池中执行，不阻塞 event loop"""
+    import threading
+    from sensenova_claw.kernel.events.envelope import EventEnvelope
+
+    session_id = "sess_thread_test"
+    turn_id = "turn_thread_test"
+    await repo.create_session(session_id)
+    await repo.create_turn(turn_id, session_id, "test")
+
+    # 记录 _sync_log_event 实际执行时所在的线程
+    execution_threads: list[int] = []
+    original_sync = repo._sync_log_event
+
+    def patched_sync(event):
+        execution_threads.append(threading.get_ident())
+        return original_sync(event)
+
+    repo._sync_log_event = patched_sync
+
+    event = EventEnvelope(
+        type="test.event",
+        session_id=session_id,
+        turn_id=turn_id,
+        payload={"msg": "hello"},
+        source="test",
+    )
+    await repo.log_event(event)
+
+    # 验证 _sync_log_event 在非主线程中执行
+    assert len(execution_threads) == 1
+    assert execution_threads[0] != threading.main_thread().ident, \
+        "log_event 的同步实现应在线程池中执行，而非 event loop 主线程"
+
+
+@pytest.mark.asyncio
+async def test_concurrent_log_events_complete_correctly(repo):
+    """验证并发 log_event 不丢失数据"""
+    import asyncio
+    from sensenova_claw.kernel.events.envelope import EventEnvelope
+
+    session_id = "sess_concurrent"
+    turn_id = "turn_concurrent"
+    await repo.create_session(session_id)
+    await repo.create_turn(turn_id, session_id, "test")
+
+    # 并发写入 10 个事件
+    events = [
+        EventEnvelope(
+            type=f"test.event.{i}",
+            session_id=session_id,
+            turn_id=turn_id,
+            payload={"index": i},
+            source="test",
+        )
+        for i in range(10)
+    ]
+    await asyncio.gather(*[repo.log_event(e) for e in events])
+
+    # 验证全部写入
+    stored = await repo.get_session_events(session_id)
+    assert len(stored) == 10

--- a/tests/unit/test_session_persistence.py
+++ b/tests/unit/test_session_persistence.py
@@ -139,6 +139,7 @@ async def test_prune_sessions(repo):
     conn.execute("UPDATE sessions SET last_active = ? WHERE session_id = ?", (old_time, old_session))
     conn.commit()
     conn.close()
+    repo._local.conn = None  # 关闭后清除缓存，使下次 _conn() 重建连接
 
     # 创建一个新会话
     new_session = "sess_new"


### PR DESCRIPTION
      ## Summary

      - **SQLite 存储层重构**: `repository.py` 全面改用 `asyncio.to_thread`，将所有同步 SQLite 操作移出 event loop，避免阻塞异步调度；连接管理改为线程本地复用 + WAL 模式
      - **前端斜杠命令修复**: 修复 SlashCommandMenu 在无匹配命令时的 fallback 行为，抽取 `slashCommand.ts` 工具模块，新增 e2e 和单元测试
      - **其他修复**: 移除 `main.py` 中重复的 `/api/sessions*` 路由注册；删除 `_is_hidden_session` 中不可达死代码；更新 mineru document parser skill 描述

      ## Changes

      ### 存储层 (`repository.py`)
      - `_conn()` 改为线程本地连接复用，启用 WAL 模式
      - `init()` 改为显式清除线程本地缓存
      - 高频写入方法（`init`/`log_event`/`save_message` 等）改用 `asyncio.to_thread`
      - Session/Turn/Event/Messages 读写方法全部迁移
      - 级联删除和会话清理方法改用 `asyncio.to_thread`
      - 删除不可达死代码

      ### 前端 (`app/web/`)
      - `SlashCommandMenu.tsx`: 重构斜杠命令匹配逻辑，修复 fallback 行为
      - `slashCommand.ts`: 新增工具函数，抽离命令解析逻辑
      - `ChatInput.tsx`: 适配新的斜杠命令接口
      - `MessageContext.tsx`: 增强消息上下文处理

      ### 测试
      - `test_session_persistence.py`: 新增 `asyncio.to_thread` 迁移验证测试
      - `chat-slash-command-fallback.spec.ts`: 新增前端 e2e 测试
      - `slash-command.test.ts`: 新增单元测试

      ## Test plan

      - [x] 后端单元测试验证 `asyncio.to_thread` 迁移正确性
      - [x] 前端斜杠命令 e2e 测试
      - [x] 前端斜杠命令单元测试
      - [ ] 手动验证：启动后端，确认 SQLite 读写正常
      - [ ] 手动验证：前端斜杠命令输入 `/` 后的菜单交互

      🤖 Generated with [Claude Code](https://claude.com/claude-code)