### PR TITLE
fix: install.sh 网络检测失败时脚本异常退出

### DIFF
--- a/install/install.sh
+++ b/install/install.sh
@@ -85,7 +85,7 @@ detect_region() {
   if command_exists jq; then
     country_code=$(echo "$resp" | jq -r '.country_code // empty' 2>/dev/null)
   else
-    country_code=$(echo "$resp" | grep -o '"country_code":"[^"]*"' | head -1 | cut -d'"' -f4)
+    country_code=$(echo "$resp" | grep -o '"country_code":"[^"]*"' | head -1 | cut -d'"' -f4 || true)
   fi
 
   if [ "$country_code" = "CN" ]; then


### PR DESCRIPTION
## Summary
- 修复 `install.sh` 在 `detect_region` 阶段因 API 返回无 `country_code` 字段导致脚本退出的问题
- 原因：`grep -o` 匹配不到内容返回退出码 1，配合 `set -euo pipefail` 导致脚本终止
- 修复：在 grep 管道末尾添加 `|| true`，使 `country_code` 为空时脚本继续执行

## Test plan
- [ ] 在无 `jq` 的环境下运行 `bash install/install.sh --dev`，确认网络检测步骤不再退出
- [ ] 确认国内网络（返回 `country_code: CN`）时仍能正确识别并配置镜像

🤖 Generated with [Claude Code](https://claude.com/claude-code)