### PR TITLE
fix: Windows 安装脚本兼容性修复

### DIFF
--- a/install/install.ps1
+++ b/install/install.ps1
@@ -35,7 +35,9 @@ function Info { param($msg) Write-Host "[i] $msg" -ForegroundColor Cyan }
 function Fail {
     param($msg)
     Err $msg
-    exit 1
+    Write-Host ""
+    Write-Host "安装中断，请根据以上错误信息排查后重试。" -ForegroundColor Yellow
+    throw $msg
 }
 
 function Command-Exists {
@@ -105,7 +107,8 @@ function Install-Uv {
     }
 
     Info "安装 uv..."
-    irm https://astral.sh/uv/install.ps1 | iex
+    # 在子进程中执行 uv 安装脚本，防止其内部 exit 终止宿主 PowerShell
+    powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://astral.sh/uv/install.ps1 | iex"
 
     # 刷新 PATH
     $env:PATH = "$env:USERPROFILE\.local\bin;$env:USERPROFILE\.cargo\bin;$env:PATH"
@@ -147,8 +150,8 @@ function Install-Fnm {
     if (Command-Exists winget) {
         winget install Schniz.fnm --accept-package-agreements --accept-source-agreements 2>$null
     } else {
-        # 降级：PowerShell 安装
-        irm https://fnm.vercel.app/install.ps1 | iex
+        # 降级：PowerShell 安装（子进程执行，防止 exit 终止宿主）
+        powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://fnm.vercel.app/install.ps1 | iex"
     }
 
     # 刷新 PATH

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -25,9 +25,6 @@ $CN_FNM_MIRROR = "https://npmmirror.com/mirrors/node"
 
 $IS_CN = $false
 
-# 当前 PowerShell 可执行路径（兼容 powershell.exe 和 pwsh.exe）
-$PS_EXE = (Get-Process -Id $PID).Path
-
 # ── 工具函数 ──
 
 function Log { param($msg) Write-Host "[+] $msg" -ForegroundColor Green }
@@ -41,6 +38,14 @@ function Fail {
     Write-Host ""
     Write-Host "安装中断，请根据以上错误信息排查后重试。" -ForegroundColor Yellow
     throw $msg
+}
+
+# 安全执行远程安装脚本：下载内容后替换 exit 为 return，防止终止宿主进程
+function Invoke-RemoteInstall {
+    param($url)
+    $scriptContent = Invoke-RestMethod $url
+    $safeScript = $scriptContent -replace '\bexit\b', 'return'
+    Invoke-Expression $safeScript
 }
 
 function Command-Exists {
@@ -110,8 +115,7 @@ function Install-Uv {
     }
 
     Info "安装 uv..."
-    # 在子进程中执行 uv 安装脚本，防止其内部 exit 终止宿主 PowerShell
-    & $PS_EXE -NoProfile -ExecutionPolicy Bypass -Command "irm https://astral.sh/uv/install.ps1 | iex"
+    Invoke-RemoteInstall "https://astral.sh/uv/install.ps1"
 
     # 刷新 PATH
     $env:PATH = "$env:USERPROFILE\.local\bin;$env:USERPROFILE\.cargo\bin;$env:PATH"
@@ -153,8 +157,14 @@ function Install-Fnm {
     if (Command-Exists winget) {
         winget install Schniz.fnm --accept-package-agreements --accept-source-agreements 2>$null
     } else {
-        # 降级：PowerShell 安装（子进程执行，防止 exit 终止宿主）
-        & $PS_EXE -NoProfile -ExecutionPolicy Bypass -Command "irm https://fnm.vercel.app/install.ps1 | iex"
+        # 降级：从 GitHub Releases 直接下载 fnm 二进制
+        Info "从 GitHub 下载 fnm..."
+        $fnmZip = "$env:TEMP\fnm-windows.zip"
+        $fnmDir = "$env:LOCALAPPDATA\fnm"
+        Invoke-WebRequest -Uri "https://github.com/Schniz/fnm/releases/latest/download/fnm-windows.zip" -OutFile $fnmZip -UseBasicParsing
+        New-Item -ItemType Directory -Force -Path $fnmDir | Out-Null
+        Expand-Archive -Path $fnmZip -DestinationPath $fnmDir -Force
+        Remove-Item $fnmZip -ErrorAction SilentlyContinue
     }
 
     # 刷新 PATH

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -167,6 +167,10 @@ function Install-Fnm {
         Remove-Item $fnmZip -ErrorAction SilentlyContinue
     }
 
+    # 设置 fnm 数据目录到用户可写路径，避免权限问题
+    $env:FNM_DIR = "$env:LOCALAPPDATA\fnm\node-versions"
+    New-Item -ItemType Directory -Force -Path $env:FNM_DIR | Out-Null
+
     # 刷新 PATH
     $env:PATH = "$env:APPDATA\fnm;$env:LOCALAPPDATA\fnm;$env:PATH"
 
@@ -196,7 +200,7 @@ function Install-Node {
     }
 
     fnm install --lts
-    fnm use --lts
+    fnm use lts-latest
     fnm env --use-on-cd | Out-String | Invoke-Expression
 
     if ((Command-Exists node) -and (Command-Exists npm)) {

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -182,7 +182,10 @@ function Install-Node {
 
     $nodeZip = "$env:TEMP\node-$ltsVersion-win-x64.zip"
     $nodeMirror = if ($IS_CN) { $CN_NODE_MIRROR } else { "https://nodejs.org/dist" }
+    $prevProgressPref = $ProgressPreference
+    $ProgressPreference = "SilentlyContinue"
     Invoke-WebRequest -Uri "$nodeMirror/$ltsVersion/node-$ltsVersion-win-x64.zip" -OutFile $nodeZip -UseBasicParsing
+    $ProgressPreference = $prevProgressPref
 
     # 解压到用户目录
     New-Item -ItemType Directory -Force -Path $nodeDir | Out-Null

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -8,6 +8,7 @@
 #
 
 $ErrorActionPreference = "Stop"
+Set-ExecutionPolicy -ExecutionPolicy Bypass -Scope Process -Force
 
 # ── 配置 ──
 

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -25,6 +25,9 @@ $CN_FNM_MIRROR = "https://npmmirror.com/mirrors/node"
 
 $IS_CN = $false
 
+# 当前 PowerShell 可执行路径（兼容 powershell.exe 和 pwsh.exe）
+$PS_EXE = (Get-Process -Id $PID).Path
+
 # ── 工具函数 ──
 
 function Log { param($msg) Write-Host "[+] $msg" -ForegroundColor Green }
@@ -108,7 +111,7 @@ function Install-Uv {
 
     Info "安装 uv..."
     # 在子进程中执行 uv 安装脚本，防止其内部 exit 终止宿主 PowerShell
-    powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://astral.sh/uv/install.ps1 | iex"
+    & $PS_EXE -NoProfile -ExecutionPolicy Bypass -Command "irm https://astral.sh/uv/install.ps1 | iex"
 
     # 刷新 PATH
     $env:PATH = "$env:USERPROFILE\.local\bin;$env:USERPROFILE\.cargo\bin;$env:PATH"
@@ -151,7 +154,7 @@ function Install-Fnm {
         winget install Schniz.fnm --accept-package-agreements --accept-source-agreements 2>$null
     } else {
         # 降级：PowerShell 安装（子进程执行，防止 exit 终止宿主）
-        powershell -NoProfile -ExecutionPolicy Bypass -Command "irm https://fnm.vercel.app/install.ps1 | iex"
+        & $PS_EXE -NoProfile -ExecutionPolicy Bypass -Command "irm https://fnm.vercel.app/install.ps1 | iex"
     }
 
     # 刷新 PATH

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -21,7 +21,7 @@ $REQUIRED_NODE = 18
 # 国内镜像
 $CN_NPM_REGISTRY = "https://registry.npmmirror.com"
 $CN_PIP_INDEX = "https://mirrors.aliyun.com/pypi/simple/"
-$CN_FNM_MIRROR = "https://npmmirror.com/mirrors/node"
+$CN_NODE_MIRROR = "https://npmmirror.com/mirrors/node"
 
 $IS_CN = $false
 
@@ -143,45 +143,7 @@ function Install-Python {
     Log "Python $REQUIRED_PYTHON 安装成功"
 }
 
-# ── 步骤 3: 安装 fnm + Node.js ──
-
-function Install-Fnm {
-    if (Command-Exists fnm) {
-        Log "fnm 已安装"
-        return
-    }
-
-    Info "安装 fnm (Node.js 版本管理器)..."
-
-    # 尝试 winget
-    if (Command-Exists winget) {
-        winget install Schniz.fnm --accept-package-agreements --accept-source-agreements 2>$null
-    } else {
-        # 降级：从 GitHub Releases 直接下载 fnm 二进制
-        Info "从 GitHub 下载 fnm..."
-        $fnmZip = "$env:TEMP\fnm-windows.zip"
-        $fnmDir = "$env:LOCALAPPDATA\fnm"
-        Invoke-WebRequest -Uri "https://github.com/Schniz/fnm/releases/latest/download/fnm-windows.zip" -OutFile $fnmZip -UseBasicParsing
-        New-Item -ItemType Directory -Force -Path $fnmDir | Out-Null
-        Expand-Archive -Path $fnmZip -DestinationPath $fnmDir -Force
-        Remove-Item $fnmZip -ErrorAction SilentlyContinue
-    }
-
-    # 设置 fnm 数据目录到用户可写路径，避免权限问题
-    $env:FNM_DIR = "$env:LOCALAPPDATA\fnm\node-versions"
-    New-Item -ItemType Directory -Force -Path $env:FNM_DIR | Out-Null
-
-    # 刷新 PATH
-    $env:PATH = "$env:APPDATA\fnm;$env:LOCALAPPDATA\fnm;$env:PATH"
-
-    if (Command-Exists fnm) {
-        Log "fnm 安装成功"
-        # 初始化 fnm 环境
-        fnm env --use-on-cd | Out-String | Invoke-Expression
-    } else {
-        Fail "fnm 安装失败，请手动安装: https://github.com/Schniz/fnm#installation"
-    }
-}
+# ── 步骤 3: 安装 Node.js ──
 
 function Install-Node {
     if (Command-Exists node) {
@@ -193,15 +155,42 @@ function Install-Node {
         Warn "Node.js 版本 $(node -v) 低于要求的 v$REQUIRED_NODE"
     }
 
-    Info "通过 fnm 安装 Node.js LTS..."
-
-    if ($IS_CN) {
-        $env:FNM_NODE_DIST_MIRROR = $CN_FNM_MIRROR
+    # 方式 1: 尝试 winget
+    if (Command-Exists winget) {
+        Info "通过 winget 安装 Node.js LTS..."
+        winget install OpenJS.NodeJS.LTS --accept-package-agreements --accept-source-agreements 2>$null
+        # winget 安装后刷新 PATH
+        $env:PATH = [System.Environment]::GetEnvironmentVariable("Path", "Machine") + ";" + [System.Environment]::GetEnvironmentVariable("Path", "User")
+        if (Command-Exists node) {
+            Log "Node.js 安装成功: $(node -v)"
+            return
+        }
+        Warn "winget 安装 Node.js 失败，尝试直接下载"
     }
 
-    fnm install --lts
-    fnm use lts-latest
-    fnm env --use-on-cd | Out-String | Invoke-Expression
+    # 方式 2: 直接从 nodejs.org 下载 zip 到用户目录
+    Info "从 nodejs.org 下载 Node.js..."
+    $nodeDir = "$SENSENOVA_CLAW_HOME\node"
+
+    # 获取最新 LTS 版本号
+    $nodeVersions = Invoke-RestMethod "https://nodejs.org/dist/index.json"
+    $ltsVersion = ($nodeVersions | Where-Object { $_.lts } | Select-Object -First 1).version
+    if (-not $ltsVersion) {
+        Fail "无法获取 Node.js LTS 版本信息"
+    }
+    Info "最新 LTS 版本: $ltsVersion"
+
+    $nodeZip = "$env:TEMP\node-$ltsVersion-win-x64.zip"
+    $nodeMirror = if ($IS_CN) { $CN_NODE_MIRROR } else { "https://nodejs.org/dist" }
+    Invoke-WebRequest -Uri "$nodeMirror/$ltsVersion/node-$ltsVersion-win-x64.zip" -OutFile $nodeZip -UseBasicParsing
+
+    # 解压到用户目录
+    New-Item -ItemType Directory -Force -Path $nodeDir | Out-Null
+    Expand-Archive -Path $nodeZip -DestinationPath $nodeDir -Force
+    Remove-Item $nodeZip -ErrorAction SilentlyContinue
+
+    # 添加到 PATH
+    $env:PATH = "$nodeDir\node-$ltsVersion-win-x64;$env:PATH"
 
     if ((Command-Exists node) -and (Command-Exists npm)) {
         Log "Node.js 安装成功: $(node -v)"
@@ -403,7 +392,6 @@ function Main {
     Configure-CN-Mirrors
     Install-Uv
     Install-Python
-    Install-Fnm
     Install-Node
     Setup-Repo
     Install-Deps

--- a/install/install.ps1
+++ b/install/install.ps1
@@ -1,4 +1,4 @@
-﻿# Sensenova-Claw 一键安装脚本（Windows PowerShell）
+# Sensenova-Claw 一键安装脚本（Windows PowerShell）
 #
 # 用法:
 #   irm https://raw.githubusercontent.com/SenseTime-FVG/sensenova_claw/dev/install/install.ps1 | iex


### PR DESCRIPTION
## Summary

  解决在受限 Windows 环境下通过 `irm | iex` 一键安装的多个兼容性问题。

  ## 修复详情

  | 问题 | 修复 |
  | UTF-8 BOM 导致 `irm \| iex` 报错 | 移除文件头 BOM 字节 |
  | 外部安装脚本内部 `exit` 导致 PowerShell 闪退 | 下载脚本内容后替换 `exit` 为 `return` 再执行 |
  | `powershell.exe` 被安全策略禁止启动子进程 | 不再依赖子进程，改用 `Invoke-RemoteInstall` 在当前进程安全执行 |
  | fnm 多重问题（权限、URL 404、参数不兼容） | 移除 fnm 依赖，直接从 nodejs.org 下载 Node.js zip 到用户目录 |
  | Node.js 下载进度条阻塞需回车 | 临时禁用 `ProgressPreference` |
  | `npm.ps1` 被执行策略拦截 | 脚本开头设置 `ExecutionPolicy Bypass -Scope Process` |
  | 错误时 `exit 1` 关闭窗口，用户看不到错误信息 | 改用 `throw` 保留错误信息 |