### PR TITLE
issues-zy

### DIFF
--- a/sensenova_claw/app/web/app/ppt/page.tsx
+++ b/sensenova_claw/app/web/app/ppt/page.tsx
@@ -45,6 +45,8 @@ import { cn } from '@/lib/utils';
 import { authFetch, API_BASE } from '@/lib/authFetch';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import { type SessionItem, getAgentId, getTitle, timeLabel } from '@/lib/chatTypes';
+import { SessionContextMenu } from '@/components/session/SessionContextMenu';
+import { InlineSessionTitleEditor } from '@/components/session/InlineSessionTitleEditor';
 
 // ── 左栏 Tab 定义 ──
 
@@ -93,6 +95,7 @@ function PPTWorkspace() {
     switchSession,
     createSession,
     deleteSession,
+    renameSession,
     startNewChat,
     loadingSessions,
   } = useChatSession();
@@ -138,6 +141,10 @@ function PPTWorkspace() {
   const [leftTab, setLeftTab] = useState<LeftTab>('outline');
   const [previewPptx, setPreviewPptx] = useState<DroppedFile | null>(null);
   const [loadingDrop, setLoadingDrop] = useState(false);
+  const [panelSizes, setPanelSizes] = useState({ left: 22, stage: 46, chat: 32, sessions: 20 });
+  const [contextMenu, setContextMenu] = useState<{ session: SessionItem; x: number; y: number } | null>(null);
+  const [editingSessionId, setEditingSessionId] = useState<string | null>(null);
+  const [renameValue, setRenameValue] = useState('');
   const dropContainerRef = useRef<HTMLDivElement>(null);
   const chatPanelRef = useRef<ChatPanelHandle>(null);
 
@@ -199,8 +206,45 @@ function PPTWorkspace() {
     [dropRef],
   );
 
+  useEffect(() => {
+    const updatePanelSizes = () => {
+      const width = window.innerWidth;
+      if (width < 1360) {
+        setPanelSizes({ left: 20, stage: 40, chat: 40, sessions: 16 });
+        return;
+      }
+      if (width < 1680) {
+        setPanelSizes({ left: 21, stage: 43, chat: 36, sessions: 18 });
+        return;
+      }
+      setPanelSizes({ left: 22, stage: 46, chat: 32, sessions: 20 });
+    };
+    updatePanelSizes();
+    window.addEventListener('resize', updatePanelSizes);
+    return () => window.removeEventListener('resize', updatePanelSizes);
+  }, []);
+
   const hasDeck = !!deckData.slideSet || !!deckData.storyboard;
   const stages = hasDeck ? deckData.stages : DEFAULT_STAGES;
+
+  const startRename = () => {
+    if (!contextMenu) return;
+    setEditingSessionId(contextMenu.session.session_id);
+    setRenameValue(getTitle(contextMenu.session.meta));
+  };
+
+  const cancelRename = () => {
+    setEditingSessionId(null);
+    setRenameValue('');
+  };
+
+  const submitRename = async () => {
+    if (!editingSessionId) return;
+    const success = await renameSession(editingSessionId, renameValue);
+    if (success) {
+      cancelRename();
+    }
+  };
 
   // ── 工作台模式（三栏布局） ──
   return (
@@ -238,7 +282,7 @@ function PPTWorkspace() {
       <ResizablePanelGroup orientation="horizontal" className="flex-1 overflow-hidden">
 
         {/* 左栏：大纲 / 风格 / 审查 / 讲稿 */}
-        <ResizablePanel id="ppt-left" defaultSize="22%" minSize="14%" maxSize="35%" className="overflow-hidden border-r border-border/40">
+        <ResizablePanel id="ppt-left" defaultSize={`${panelSizes.left}%`} minSize="14%" maxSize="35%" className="overflow-hidden border-r border-border/40">
           <div className="flex flex-col h-full">
             {/* Tab 切换栏 */}
             <div className="flex items-center border-b border-border/40 shrink-0 px-0.5">
@@ -314,7 +358,7 @@ function PPTWorkspace() {
         <ResizableHandle invisible />
 
         {/* 中栏：幻灯片主舞台 */}
-        <ResizablePanel id="ppt-stage" defaultSize="46%" minSize="25%" className="overflow-hidden relative">
+        <ResizablePanel id="ppt-stage" defaultSize={`${panelSizes.stage}%`} minSize="25%" className="overflow-hidden relative">
           <div className="flex flex-col h-full">
             {previewPptx ? (
               <PptxPreview file={previewPptx} onClose={() => setPreviewPptx(null)} />
@@ -352,10 +396,10 @@ function PPTWorkspace() {
         <ResizableHandle invisible />
 
         {/* 右栏：会话列表 + 对话面板（上下可拖拽调整） */}
-        <ResizablePanel id="ppt-chat" defaultSize="32%" minSize="20%" maxSize="45%" className="overflow-hidden border-l border-border/40">
+        <ResizablePanel id="ppt-chat" defaultSize={`${panelSizes.chat}%`} minSize="20%" maxSize="45%" className="overflow-hidden border-l border-border/40">
           <ResizablePanelGroup orientation="vertical" className="h-full">
             {/* 上部：会话列表（可上下拖拽边框调整高度） */}
-            <ResizablePanel id="ppt-sessions" defaultSize="20%" minSize="8%" maxSize="50%" className="overflow-hidden">
+            <ResizablePanel id="ppt-sessions" defaultSize={`${panelSizes.sessions}%`} minSize="8%" maxSize="50%" className="overflow-hidden">
               <div className="flex flex-col h-full">
                 <div className="flex items-center justify-between px-3 py-1.5 shrink-0">
                   <div className="flex items-center gap-1.5">
@@ -387,6 +431,12 @@ function PPTWorkspace() {
                           key={session.session_id}
                           type="button"
                           onClick={() => switchSession(session.session_id)}
+                          onContextMenu={(event) => {
+                            event.preventDefault();
+                            event.stopPropagation();
+                            setContextMenu({ session, x: event.clientX, y: event.clientY });
+                          }}
+                          data-testid={`ppt-session-item-${session.session_id}`}
                           className={cn(
                             'w-full flex items-center gap-2 px-2 py-1.5 rounded-lg text-left transition-all text-[11px] group',
                             isActive
@@ -395,7 +445,18 @@ function PPTWorkspace() {
                           )}
                         >
                           <MessageSquare className={cn('w-3 h-3 shrink-0', isActive ? 'text-primary' : 'text-muted-foreground/40')} />
-                          <span className="flex-1 truncate font-medium">{title}</span>
+                          {editingSessionId === session.session_id ? (
+                            <InlineSessionTitleEditor
+                              value={renameValue}
+                              onChange={setRenameValue}
+                              onSubmit={submitRename}
+                              onCancel={cancelRename}
+                              testId={`ppt-rename-input-${session.session_id}`}
+                              className="flex-1 rounded border border-primary/40 bg-background px-1.5 py-0.5 text-[11px] font-medium text-foreground outline-none ring-0"
+                            />
+                          ) : (
+                            <span className="flex-1 truncate font-medium">{title}</span>
+                          )}
                           <span className="text-[9px] text-muted-foreground/40 shrink-0">{timeLabel(session.last_active)}</span>
                           <button
                             type="button"
@@ -425,6 +486,15 @@ function PPTWorkspace() {
           </ResizablePanelGroup>
         </ResizablePanel>
       </ResizablePanelGroup>
+
+      <SessionContextMenu
+        open={!!contextMenu}
+        x={contextMenu?.x ?? 0}
+        y={contextMenu?.y ?? 0}
+        onClose={() => setContextMenu(null)}
+        onRename={startRename}
+        testId="ppt-session-context-menu"
+      />
 
       {/* ── 底栏：模板条 ── */}
       <div className="shrink-0 border-t border-border/40 bg-muted/10">

--- a/sensenova_claw/app/web/components/files/GlobalFilePanel.tsx
+++ b/sensenova_claw/app/web/components/files/GlobalFilePanel.tsx
@@ -137,7 +137,7 @@ function FileTreeItem({ item, depth = 0, expandToPath, onContextMenu, onFileClic
         ) : (
           <File className={cn('w-4 h-4 shrink-0', isTarget ? 'text-primary' : 'text-muted-foreground')} />
         )}
-        <span className={cn('truncate text-xs', isTarget ? 'text-primary' : 'text-foreground/80')}>
+        <span className={cn('whitespace-nowrap text-xs', isTarget ? 'text-primary' : 'text-foreground/80')}>
           {item.name}
         </span>
         {loading && <Loader2 className="w-3 h-3 text-muted-foreground ml-auto animate-spin" />}
@@ -536,8 +536,8 @@ export function GlobalFilePanel() {
               )}
             </div>
           )}
-          <div className="flex-1 overflow-y-auto py-1">
-            <div className="space-y-0.5 px-1" key={localTreeKey}>
+          <div className="flex-1 overflow-auto py-1">
+            <div className="space-y-0.5 px-1 min-w-max" key={localTreeKey}>
               {roots.map(r => (
                 <FileTreeItem
                   key={r.path}


### PR DESCRIPTION
1.文件区不能左右滚动 #222 【已解决】
/ppt 页面大屏/小屏比例自适应
在 page.tsx (line 144) 增加了基于 window.innerWidth 的面板比例计算。
分别在窄屏/中屏/宽屏下调整 left/stage/chat/sessions 默认占比，并绑定 resize 实时更新。
替换了四个 ResizablePanel 的固定 defaultSize 为自适应值（见同文件 285、361、399、402 行附近）。

2.显示内容重叠 #216 【已解决】
文件区支持左右滑动，避免内容显示不全
在 GlobalFilePanel.tsx (line 539) 将文件树容器改为 overflow-auto。
在 GlobalFilePanel.tsx (line 540) 为列表容器加 min-w-max，允许横向内容撑开。
在 GlobalFilePanel.tsx (line 140) 把文件名从 truncate 改为 whitespace-nowrap，配合横向滚动查看完整名称。