### PR TITLE
resolve issue #211: 消息气泡显示本轮agent回复耗时

### DIFF
--- a/sensenova_claw/app/web/components/chat/MessageBubble.tsx
+++ b/sensenova_claw/app/web/components/chat/MessageBubble.tsx
@@ -11,6 +11,19 @@ import { AskUserResponseForm } from '@/components/chat/AskUserResponseForm';
 
 const MAX_TOOL_CONTENT_HEIGHT = 240;
 
+/**
+ * Issue #211: 把毫秒数格式化为中文耗时字符串，如 "3分15秒"、"12秒"。
+ * 小于 1 秒向上取到 1 秒，避免显示 "0秒"。
+ */
+function formatDurationZh(ms: number): string {
+  if (!Number.isFinite(ms) || ms < 0) return '';
+  const totalSeconds = Math.max(1, Math.round(ms / 1000));
+  if (totalSeconds < 60) return `${totalSeconds}秒`;
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}分${seconds}秒`;
+}
+
 function ToolContent({ value }: { value: unknown }) {
   if (!value) return <span className="text-muted-foreground italic">empty</span>;
   if (isJsonLike(value)) {
@@ -211,6 +224,15 @@ export const MessageBubble = memo(function MessageBubble({ msg }: { msg: ChatMes
           {parsedAssistantContent.answerContent ? (
             <div className="text-base md:text-lg text-foreground leading-relaxed">
               <Markdown content={parsedAssistantContent.answerContent} />
+            </div>
+          ) : null}
+          {typeof msg.durationMs === 'number' ? (
+            <div
+              className="text-xs text-muted-foreground assistant-duration"
+              data-testid="assistant-duration"
+              title="从你发送消息到本次回复完成的耗时"
+            >
+              耗时 {formatDurationZh(msg.durationMs)}
             </div>
           ) : null}
         </div>

--- a/sensenova_claw/app/web/contexts/ws/MessageContext.tsx
+++ b/sensenova_claw/app/web/contexts/ws/MessageContext.tsx
@@ -382,26 +382,46 @@ export function MessageProvider({ children }: { children: React.ReactNode }) {
             if (lastStreamingTurnIdRef.current === completedTurnId) lastStreamingTurnIdRef.current = null;
           }
           setMessages((prev) => {
+            // Issue #211: 找最近一条 user 消息的 timestamp，计算从用户发送到 response 完成的耗时
+            let durationMs: number | undefined;
+            for (let i = prev.length - 1; i >= 0; i--) {
+              if (prev[i].role === 'user') {
+                const delta = Date.now() - prev[i].timestamp;
+                if (delta >= 0) durationMs = delta;
+                break;
+              }
+            }
+
             if (completedTurnId) {
               // 只更新最后一条同 turnId 的 assistant 消息，保留早期消息的 thinking 不变。
-              // 注意：不设置 thinkingState，思考过程默认展开显示。
-              return upsertAssistantTurnMessage(prev, completedTurnId, {
+              const afterUpsert = upsertAssistantTurnMessage(prev, completedTurnId, {
                 content: final,
                 keepExistingContentWhenEmpty: true,
               });
+              if (durationMs === undefined) return afterUpsert;
+              // 把 duration 写到最后一条同 turnId 的 assistant 消息上
+              for (let i = afterUpsert.length - 1; i >= 0; i--) {
+                const m = afterUpsert[i];
+                if (m.role === 'assistant' && m.turnId === completedTurnId) {
+                  const next = [...afterUpsert];
+                  next[i] = { ...m, durationMs };
+                  return next;
+                }
+              }
+              return afterUpsert;
             }
             for (let i = prev.length - 1; i >= 0; i--) {
               if (prev[i].role === 'assistant') {
                 const existing = prev[i];
-                // 如果 llm_result 已经设置了相同内容，保持不变
+                // 如果 llm_result 已经设置了相同内容，只补 durationMs
                 if (existing.content === final || !final) {
-                  return prev;
+                  if (durationMs === undefined) return prev;
+                  const next = [...prev]; next[i] = { ...existing, durationMs }; return next;
                 }
-                // 内容不同时才更新（不创建新消息）
-                const next = [...prev]; next[i] = { ...next[i], content: final }; return next;
+                const next = [...prev]; next[i] = { ...existing, content: final, durationMs }; return next;
               }
             }
-            if (final) return [...prev, { id: makeId(), role: 'assistant', content: final, timestamp: Date.now() }];
+            if (final) return [...prev, { id: makeId(), role: 'assistant', content: final, timestamp: Date.now(), durationMs }];
             return prev;
           });
           setIsTyping(false);

--- a/sensenova_claw/app/web/lib/chatTypes.ts
+++ b/sensenova_claw/app/web/lib/chatTypes.ts
@@ -47,6 +47,8 @@ export interface ChatMessage {
   /** 工具消息在没有 toolInfo 时展示的工具名。 */
   name?: string;
   toolInfo?: ToolInfo;
+  /** Issue #211: assistant 最终回复时填充，表示从用户最近一条消息到该回复完成的耗时（ms）。 */
+  durationMs?: number;
 }
 
 export interface SessionItem {


### PR DESCRIPTION
feat(web): 在 assistant 消息气泡显示本轮对话耗时 (#211)

在前端 `turn_completed` 事件到达时，取最近一条 user 消息的 timestamp 与当前时间求差，作为 "从用户发出消息到 agent 回复完成" 的耗时，写入对应的最终 assistant 消息 `durationMs` 字段，并在气泡底部以 "耗时 X分Y秒" / "耗时 X秒" 的中文格式显示。仅对 live 新对话生效，历史会话自然不展示。

<img width="1257" height="881" alt="image" src="https://github.com/user-attachments/assets/62c738a9-7b8d-4e71-abd8-9fa77186d4c9" />
