### PR TITLE
fix gemini reasoning display

### DIFF
--- a/sensenova_claw/adapters/llm/providers/gemini_provider.py
+++ b/sensenova_claw/adapters/llm/providers/gemini_provider.py
@@ -29,6 +29,77 @@ def _extract_reasoning_details(message: dict[str, Any]) -> list[dict[str, Any]]:
     return rd if isinstance(rd, list) else []
 
 
+def _normalize_reasoning_details(reasoning_details: Any) -> list[dict[str, Any]]:
+    """归一化 Gemini reasoning_details，补出前端可展示的 thinking 条目。
+
+    Gemini / 兼容网关在工具调用场景下常返回两类 reasoning 数据：
+    1. `type=tool` 的内部签名元数据（用于后续请求续传 thought signature）
+    2. 带 `text` / `thinking` / `summary` / `content` 的可读文本
+
+    当前前端只会展示 `type=thinking` 的条目，因此这里在保留原始结构的同时，
+    把可读文本补成额外的 `type=thinking` 条目，避免改动事件协议或前端逻辑。
+    """
+    if not isinstance(reasoning_details, list):
+        return []
+
+    normalized: list[dict[str, Any]] = []
+    seen_thinking: set[str] = set()
+    text_keys = ("thinking", "text", "summary", "content")
+
+    for item in reasoning_details:
+        if not isinstance(item, dict):
+            continue
+        detail = deepcopy(item)
+        normalized.append(detail)
+
+        detail_type = str(detail.get("type", "") or "").strip().lower()
+        text_value = ""
+        for key in text_keys:
+            value = detail.get(key)
+            if isinstance(value, str) and value.strip():
+                text_value = value.strip()
+                break
+
+        if not text_value:
+            continue
+
+        if detail_type == "thinking":
+            seen_thinking.add(text_value)
+            continue
+
+        if detail_type == "tool":
+            # tool 条目主要是 thought signature 元数据；只有当它真的带了可读文本时，
+            # 才额外补一条 thinking 供 UI 展示。
+            pass
+
+        if text_value in seen_thinking:
+            continue
+        seen_thinking.add(text_value)
+        normalized.append({"type": "thinking", "thinking": text_value})
+
+    return normalized
+
+
+def _append_reasoning_content(
+    reasoning_details: list[dict[str, Any]],
+    reasoning_content: Any,
+) -> list[dict[str, Any]]:
+    """把 Gemini 返回的 reasoning_content 追加为可展示的 thinking 条目。"""
+    if not isinstance(reasoning_content, str) or not reasoning_content.strip():
+        return reasoning_details
+
+    text = reasoning_content.strip()
+    for item in reasoning_details:
+        if (
+            isinstance(item, dict)
+            and str(item.get("type", "") or "").strip().lower() == "thinking"
+            and str(item.get("thinking", "") or "").strip() == text
+        ):
+            return reasoning_details
+
+    return [*reasoning_details, {"type": "thinking", "thinking": text}]
+
+
 def _tool_call_has_thought_sig(tc: dict[str, Any]) -> bool:
     """检测单个 tool_call 是否包含 Chat Completions 格式的 thought signature。
 
@@ -161,15 +232,28 @@ class GeminiProvider(LLMProvider):
             psf = extra.get("provider_specific_fields") or {}
             reasoning_details = psf.get("reasoning_details")
 
-        if reasoning_details:
-            result["reasoning_details"] = reasoning_details
+        reasoning_content = extra.get("reasoning_content")
+        if not reasoning_content:
+            psf = extra.get("provider_specific_fields") or {}
+            reasoning_content = psf.get("reasoning_content")
+
+        normalized_reasoning_details = _normalize_reasoning_details(reasoning_details)
+        normalized_reasoning_details = _append_reasoning_content(
+            normalized_reasoning_details,
+            reasoning_content,
+        )
+
+        if normalized_reasoning_details:
+            result["reasoning_details"] = normalized_reasoning_details
             has_tool_sig = any(
                 isinstance(item, dict) and item.get("type") == "tool" and item.get("signature")
-                for item in reasoning_details
+                for item in normalized_reasoning_details
             )
             logger.debug(
-                "Gemini reasoning_details: %d items, has_tool_signature=%s",
-                len(reasoning_details), has_tool_sig,
+                "Gemini reasoning_details: raw=%d normalized=%d has_tool_signature=%s has_reasoning_content=%s",
+                len(reasoning_details) if isinstance(reasoning_details, list) else 0,
+                len(normalized_reasoning_details), has_tool_sig,
+                bool(isinstance(reasoning_content, str) and reasoning_content.strip()),
             )
 
         has_ec_sig = any(_tool_call_has_thought_sig(tc) for tc in tool_calls)


### PR DESCRIPTION
## 变更内容

修复 Gemini provider 在工具调用场景下思考内容无法在前端展示的问题。

本次修改仅调整 `sensenova_claw/adapters/llm/providers/gemini_provider.py`，未改动前端展示逻辑，也未修改 websocket 事件协议。

## 问题现象

在 Claude Opus 对话中，UI 可以显示模型的思考过程，例如“我现在要调用……”。

但在 Gemini 对话中，页面只显示 `read_file`、`bash_command` 等工具调用记录，看不到对应的思考内容。

## 根因分析

前端本身的思考内容展示链路是正常的，Claude 能显示已经说明这一点。

实际问题出在 Gemini provider 的字段提取上：

- 旧实现主要读取 `reasoning_details`
- 但当前接入的 Gemini 兼容网关在部分响应里将思考文本放在 `message.model_extra.reasoning_content`
- provider 没有提取这个字段，导致后续 `llm_result` 中没有可展示的 reasoning 内容
- 前端最终只能看到工具调用，看不到 think 内容

从运行日志可以看到，Gemini 返回中实际存在：

- `reasoning_content`
- `encrypted_content`

说明并不是 Gemini 完全没有返回思考内容，而是 provider 层没有正确适配。

## 修复方案

在 Gemini provider 中补充对 `reasoning_content` 的提取，并将其转换为前端现有逻辑可直接消费的格式：

- `{"type": "thinking", "thinking": "..."}`

同时保留原有 `reasoning_details` / `thought_signature` 处理逻辑，避免影响 Gemini 工具调用链路。

## 影响范围

影响范围仅限 Gemini reasoning 内容的提取与归一化：

- 修复 Gemini think 内容在 UI 不显示的问题
- 不影响 Claude / OpenAI / Anthropic provider
- 不改动前端逻辑
- 不改动现有事件协议
- 不改变已有 tool signature 的透传行为

## 验证情况

已完成：

- provider 代码修复
- 本地语法校验通过

