### PR TITLE
fix ppt html export download

### DIFF
--- a/sensenova_claw/app/web/app/ppt/page.tsx
+++ b/sensenova_claw/app/web/app/ppt/page.tsx
@@ -138,6 +138,7 @@ function PPTWorkspace() {
   const [leftTab, setLeftTab] = useState<LeftTab>('outline');
   const [previewPptx, setPreviewPptx] = useState<DroppedFile | null>(null);
   const [loadingDrop, setLoadingDrop] = useState(false);
+  const [exportingHtmlZip, setExportingHtmlZip] = useState(false);
   const dropContainerRef = useRef<HTMLDivElement>(null);
   const chatPanelRef = useRef<ChatPanelHandle>(null);
 
@@ -202,6 +203,31 @@ function PPTWorkspace() {
   const hasDeck = !!deckData.slideSet || !!deckData.storyboard;
   const stages = hasDeck ? deckData.stages : DEFAULT_STAGES;
 
+  const handleExport = useCallback(async (format: string, _withNotes: boolean) => {
+    if (format !== 'html-zip' || !deckData.deckDir || exportingHtmlZip) return;
+
+    setExportingHtmlZip(true);
+    try {
+      const res = await authFetch(
+        `${API_BASE}/api/files/workdir-archive?dir=${encodeURIComponent(deckData.deckDir)}`,
+      );
+      if (!res.ok) return;
+
+      const blob = await res.blob();
+      const url = URL.createObjectURL(blob);
+      const fileName = `${deckData.deckDir.split('/').pop() || 'deck'}.zip`;
+      const link = document.createElement('a');
+      link.href = url;
+      link.download = fileName;
+      document.body.appendChild(link);
+      link.click();
+      link.remove();
+      URL.revokeObjectURL(url);
+    } finally {
+      setExportingHtmlZip(false);
+    }
+  }, [deckData.deckDir, exportingHtmlZip]);
+
   // ── 工作台模式（三栏布局） ──
   return (
     <div ref={setRef} className="flex flex-col h-full overflow-hidden">
@@ -229,6 +255,7 @@ function PPTWorkspace() {
           </Button>
           <ExportDropdown
             deckDir={deckData.deckDir}
+            onExport={handleExport}
             hasSpeakerNotes={!!deckData.speakerNotes}
           />
         </div>

--- a/sensenova_claw/interfaces/http/files.py
+++ b/sensenova_claw/interfaces/http/files.py
@@ -11,10 +11,13 @@ import platform
 import re
 import string
 import subprocess
+import tempfile
 import time
+import zipfile
 from pathlib import Path
 from urllib.parse import unquote
 
+from starlette.background import BackgroundTask
 from fastapi import APIRouter, Form, HTTPException, Query, Request, UploadFile, File as FastAPIFile
 from fastapi.responses import FileResponse
 from pydantic import BaseModel
@@ -316,6 +319,56 @@ async def list_workdir_slides(
                     })
 
     return {"dir": dir, "slides": slides}
+
+
+@router.get("/files/workdir-archive")
+async def download_workdir_archive(
+    request: Request,
+    dir: str = Query(..., description="相对于 workdir 的目录路径"),
+):
+    """将指定 workdir 子目录打包为 zip 并下载。"""
+    workspace = _resolve_workspace_dir(request)
+    workdir = workspace / "workdir"
+    target = workdir / dir
+
+    try:
+        resolved = target.resolve()
+    except (OSError, ValueError):
+        raise HTTPException(400, f"无效路径: {dir}")
+
+    try:
+        resolved.relative_to(workdir.resolve())
+    except ValueError:
+        raise HTTPException(403, "路径越界")
+
+    if not resolved.exists() or not resolved.is_dir():
+        raise HTTPException(404, f"目录不存在: {dir}")
+
+    if not any(resolved.iterdir()):
+        raise HTTPException(400, f"目录为空: {dir}")
+
+    deck_name = resolved.name or "deck"
+    temp_zip = tempfile.NamedTemporaryFile(prefix=f"{deck_name}_", suffix=".zip", delete=False)
+    temp_zip_path = Path(temp_zip.name)
+    temp_zip.close()
+
+    try:
+        with zipfile.ZipFile(temp_zip_path, "w", compression=zipfile.ZIP_DEFLATED) as zf:
+            for file_path in resolved.rglob("*"):
+                if not file_path.is_file():
+                    continue
+                arcname = file_path.relative_to(resolved)
+                zf.write(file_path, arcname=str(arcname))
+    except Exception:
+        temp_zip_path.unlink(missing_ok=True)
+        raise
+
+    return FileResponse(
+        path=str(temp_zip_path),
+        filename=f"{deck_name}.zip",
+        media_type="application/zip",
+        background=BackgroundTask(lambda: temp_zip_path.unlink(missing_ok=True)),
+    )
 
 
 def _encode_dir_token(dir_path: str) -> str:


### PR DESCRIPTION
## 变更内容

修复 PPT 工作台中“导出 -> HTML 打包下载”点击后无响应的问题。

本次修改补齐了前后端的导出闭环：
- 前端为 HTML 打包下载补上实际导出逻辑
- 后端新增 workdir 目录打包 zip 下载接口

## 问题现象

在 PPT 生成功能完成后，点击：

导出 -> HTML 打包下载

页面没有任何反应，也不会触发文件下载。

## 根因分析

问题不在于打包过程失败，而在于导出链路本身没有接通。

具体来说：

1. `ExportDropdown` 组件只是提供了导出菜单 UI
2. 点击菜单项时只会调用可选的 `onExport?.(...)`
3. 但 PPT 页面实际使用该组件时，没有传入 `onExport`
4. 因此点击 “HTML 打包下载” 后不会触发任何动作

同时，后端原本也没有专门提供“将 deck 目录打包为 zip 下载”的接口，因此即使前端想发起下载，也缺少对应能力。

## 修复方案

### 前端

在 PPT 页面中新增 `handleExport`，当用户选择 `html-zip` 时：

- 调用后端打包接口
- 获取 zip blob
- 通过浏览器下载能力触发文件保存

### 后端

新增接口：

- `GET /api/files/workdir-archive?dir=...`

功能：
- 校验目标目录位于 workdir 下
- 将目标目录递归打包为 zip
- 返回 zip 文件下载响应
- 下载完成后自动清理临时压缩文件

## 影响范围

本次修改仅影响 PPT 工作台中的 HTML 打包下载功能：

- 修复 HTML 打包下载点击无响应的问题
- 不影响 PDF / PPTX 导出入口
- 不影响普通文件下载逻辑
- 不影响 PPT 生成流程本身

## 验证情况

已完成：
- 后端 Python 语法校验通过
- 前后端调用链已补齐

