### PR TITLE
fix: 对话中文件链接点击预览链路修复

### DIFF
--- a/sensenova_claw/app/web/app/chat/page.tsx
+++ b/sensenova_claw/app/web/app/chat/page.tsx
@@ -2,7 +2,6 @@
 
 import { Suspense, useState, useEffect, useCallback, useRef, useMemo } from 'react';
 import { useSearchParams } from 'next/navigation';
-import dynamic from 'next/dynamic';
 import {
   Loader2, Bot, MessageSquare, Plus, Search, RefreshCw, Trash2,
   ChevronDown, ChevronRight, GitBranch,
@@ -15,25 +14,14 @@ import { useI18n } from '@/contexts/I18nContext';
 import { type SessionItem, type SessionTreeNode, type ContextFileRef, buildSessionTree, getAgentId, getTitle, timeLabel } from '@/lib/chatTypes';
 import { MessageArea } from '@/components/chat/MessageArea';
 import { ChatInput } from '@/components/chat/ChatInput';
+import { InlinePreview } from '@/components/chat/InlinePreview';
 import { useSlideSet } from '@/components/ppt/PPTViewer';
+import { type FilePreviewType } from '@/components/files/fileTypes';
 import { DashboardLayout } from '@/components/layout/DashboardLayout';
 import { ResizablePanelGroup, ResizablePanel, ResizableHandle } from '@/components/ui/resizable';
 import { useResizablePreview } from '@/hooks/useResizablePreview';
 import { SessionContextMenu } from '@/components/session/SessionContextMenu';
 import { InlineSessionTitleEditor } from '@/components/session/InlineSessionTitleEditor';
-
-// Lazy load SlideViewer
-const SlideViewer = dynamic(
-  () => import('@/components/ppt/PPTViewer').then(mod => mod.SlideViewer),
-  {
-    loading: () => (
-      <div className="h-full flex items-center justify-center bg-muted/20">
-        <Loader2 className="animate-spin text-muted-foreground" />
-      </div>
-    ),
-    ssr: false,
-  },
-);
 
 /* ── workdir 根目录缓存 ── */
 let _workdirRootCache: string | null | undefined;
@@ -355,7 +343,8 @@ function ChatContent() {
   const [selectedAgentId, setSelectedAgentId] = useState<string | null>(agentFromUrl);
   const [searchQuery, setSearchQuery] = useState('');
   const [slidePreviewDir, setSlidePreviewDir] = useState<string | null>(null);
-  
+  const [filePreview, setFilePreview] = useState<{ path: string; type: FilePreviewType } | null>(null);
+
   const { previewHeight, onPreviewResize } = useResizablePreview(350);
   const slideSet = useSlideSet(slidePreviewDir);
   
@@ -384,12 +373,29 @@ function ChatContent() {
         });
       }
       setSlidePreviewDir(resolvedDir);
+      setFilePreview(null);
     };
     window.addEventListener('sensenova-claw:open-slide-preview', handler);
     return () => window.removeEventListener('sensenova-claw:open-slide-preview', handler);
   }, [selectedAgentId, currentSessionId, sessions, openToPath]);
 
-  useEffect(() => { setSlidePreviewDir(null); }, [currentSessionId]);
+  // File Preview Logic：聊天气泡里的 [..](#sensenova-claw-file:...) 链接点击会
+  // 派发此事件，这里与 slide 预览互斥共存。之前 /chat 页面漏接此事件，
+  // 导致 md 文件点击只定位到文件面板，对话区无预览。
+  useEffect(() => {
+    const handler = (e: Event) => {
+      const detail = (e as CustomEvent).detail as { path: string; type: FilePreviewType };
+      setFilePreview(detail);
+      setSlidePreviewDir(null);
+    };
+    window.addEventListener('sensenova-claw:open-file-preview', handler);
+    return () => window.removeEventListener('sensenova-claw:open-file-preview', handler);
+  }, []);
+
+  useEffect(() => {
+    setSlidePreviewDir(null);
+    setFilePreview(null);
+  }, [currentSessionId]);
 
   const loadAgents = useCallback(async () => {
     setLoadingAgents(true);
@@ -590,14 +596,14 @@ function ChatContent() {
             
             <MessageArea messages={messages} isTyping={isTyping} currentSessionId={currentSessionId} emptyState={emptyState} />
 
-            {slidePreviewDir && slideSet && (
-              <div className="shrink-0 flex flex-col border-t border-border/60" style={{ height: previewHeight }}>
-                <div className="flex items-center justify-center h-2 cursor-ns-resize hover:bg-primary/20 group transition-colors" onMouseDown={onPreviewResize}>
-                  <div className="w-8 h-1 rounded-full bg-border group-hover:bg-primary/50" />
-                </div>
-                <SlideViewer slideSet={slideSet} onClose={() => setSlidePreviewDir(null)} />
-              </div>
-            )}
+            <InlinePreview
+              previewHeight={previewHeight}
+              onPreviewResize={onPreviewResize}
+              slideSet={slideSet}
+              onCloseSlides={() => setSlidePreviewDir(null)}
+              filePreview={filePreview}
+              onCloseFile={() => setFilePreview(null)}
+            />
 
             <ChatInput
               defaultAgentId={selectedAgentId || 'default'}

--- a/sensenova_claw/kernel/runtime/path_rewriter.py
+++ b/sensenova_claw/kernel/runtime/path_rewriter.py
@@ -7,12 +7,19 @@
 
 from __future__ import annotations
 
+import posixpath
 import re
-from pathlib import Path, PurePosixPath, PureWindowsPath
+from pathlib import Path, PurePosixPath
+from urllib.parse import unquote
 
 
 # 匹配 Markdown 行内代码 `...` 中包含的文件路径
 _CODE_SPAN_RE = re.compile(r"`([^`]+)`")
+
+# 匹配 [text](#sensenova-claw-file:PATH) 形式的文件链接
+# 前端 Markdown.tsx 以此前缀识别并渲染成可点击卡片；PATH 由 LLM 产出，
+# 常因路径规则理解偏差出现相对形式，导致点击打开失败。
+_FILE_LINK_RE = re.compile(r"(\]\(#sensenova-claw-file:)([^)]*?)(\))")
 
 # 常见文件扩展名，用于判定是否像一个文件路径
 _FILE_EXTENSIONS = {
@@ -78,3 +85,81 @@ def rewrite_relative_paths(content: str, workdir: str) -> str:
         return f"`{abs_path}`"
 
     return _CODE_SPAN_RE.sub(_replace, content)
+
+
+def _is_absolute_pathlike(text: str) -> bool:
+    """跨平台判断路径是否已是绝对形式。
+
+    不依赖 ``Path.is_absolute()`` 的运行时平台行为：
+    - POSIX 上 ``PurePath('C:\\foo').is_absolute()`` 会返回 False
+    - Windows 上 ``PurePath('/a').is_absolute()`` 会返回 False
+    我们需要一个对两端输入都正确的判断（agent 可能在 Linux 沙箱跑，
+    也可能在开发机 Windows 跑；LLM 的输出平台无关）。
+    """
+    if not text:
+        return False
+    if text[0] in ("/", "\\"):
+        return True
+    # 视 ``~`` 起始为用户显式引用，不再二次解析
+    if text.startswith("~"):
+        return True
+    # Windows 盘符: C:\foo  或  C:/foo
+    if (
+        len(text) >= 3
+        and text[0].isalpha()
+        and text[1] == ":"
+        and text[2] in ("/", "\\")
+    ):
+        return True
+    return False
+
+
+def rewrite_file_link_hrefs(content: str, workdir: str) -> str:
+    """将 ``[text](#sensenova-claw-file:PATH)`` 中非绝对的 PATH 拼成绝对路径。
+
+    设计要点：
+
+    - **workdir 为空/未配置**：直接返回原文（agent 可能在开发机本地运行，
+      或未配置 workdir，此时强行拼接反而误导）。
+    - **PATH 已是绝对形式**：不改（POSIX / Windows 盘符 / ``~`` 三种）。
+    - **反斜杠归一**：Python 在 POSIX 上不把 ``\\`` 当分隔符，因此先把
+      ``\\`` 替换为 ``/``，再用 ``posixpath.normpath`` 统一处理
+      ``.``、``..``、冗余斜杠。拒绝依赖当前运行平台的 Path 行为。
+    - **URL 编码兼容**：LLM 多数直接写原始路径，也可能产出百分号编码；
+      ``unquote`` 对普通文本是 no-op，对编码文本能正确解码。
+      输出统一用解码后的原始路径，前端 ``decodeURIComponent`` 仍是 no-op。
+    - **安全边界**：越出 workdir 的 ``..`` 组合会按字面规范化，不会额外
+      阻断；下游 ``/api/files/download`` 自带 path_policy 校验，这里
+      只负责语义归一。
+    """
+    if not content or not workdir:
+        return content
+
+    try:
+        # 统一以正斜杠作为输出分隔符，避免 Windows ``\\`` 进入 markdown 后被
+        # 下游 ``decodeURIComponent`` 或 URL 解析误判。
+        workdir_abs = str(Path(workdir).expanduser().resolve()).replace("\\", "/")
+    except Exception:
+        return content
+
+    def _replace(match: re.Match) -> str:
+        prefix = match.group(1)
+        raw_href = match.group(2).strip()
+        suffix = match.group(3)
+
+        try:
+            decoded = unquote(raw_href)
+        except Exception:
+            decoded = raw_href
+
+        if not decoded or _is_absolute_pathlike(decoded):
+            return match.group(0)
+
+        normalized = decoded.replace("\\", "/")
+        # PurePosixPath 保证在任意宿主平台上的行为一致
+        joined = str(PurePosixPath(workdir_abs) / normalized)
+        abs_path = posixpath.normpath(joined)
+
+        return f"{prefix}{abs_path}{suffix}"
+
+    return _FILE_LINK_RE.sub(_replace, content)

--- a/sensenova_claw/kernel/runtime/workers/agent_worker.py
+++ b/sensenova_claw/kernel/runtime/workers/agent_worker.py
@@ -584,10 +584,16 @@ class AgentSessionWorker(SessionWorker):
 
         # 后处理：将回复中的相对路径改写为绝对路径
         from sensenova_claw.platform.config.workspace import resolve_agent_workdir, resolve_sensenova_claw_home
-        from sensenova_claw.kernel.runtime.path_rewriter import rewrite_relative_paths
+        from sensenova_claw.kernel.runtime.path_rewriter import (
+            rewrite_file_link_hrefs,
+            rewrite_relative_paths,
+        )
         _home = str(resolve_sensenova_claw_home(config))
         _workdir = resolve_agent_workdir(_home, self.agent_config)
         content = rewrite_relative_paths(content, _workdir)
+        # 文件卡片 href（#sensenova-claw-file:）里 LLM 可能塞相对路径，
+        # 前端点击会 404。此处与 inline code 规范化互补。
+        content = rewrite_file_link_hrefs(content, _workdir)
 
         state.final_response = content
         await self.rt.repo.complete_turn(event.turn_id, agent_response=content)

--- a/tests/unit/test_path_rewriter.py
+++ b/tests/unit/test_path_rewriter.py
@@ -3,7 +3,14 @@
 import platform
 import tempfile
 from pathlib import Path
-from sensenova_claw.kernel.runtime.path_rewriter import rewrite_relative_paths, _looks_like_relative_file_path
+from urllib.parse import quote
+
+from sensenova_claw.kernel.runtime.path_rewriter import (
+    _is_absolute_pathlike,
+    _looks_like_relative_file_path,
+    rewrite_file_link_hrefs,
+    rewrite_relative_paths,
+)
 
 
 class TestLooksLikeRelativeFilePath:
@@ -127,3 +134,145 @@ class TestRewriteRelativePaths:
         wd_fwd = wd.replace("\\", "/")
         assert wd_fwd in result
         assert "output.md" in result
+
+
+class TestIsAbsolutePathlike:
+    """不依赖运行平台的绝对路径判定。"""
+
+    def test_posix_absolute(self):
+        assert _is_absolute_pathlike("/sandbox/foo.md") is True
+
+    def test_backslash_root(self):
+        assert _is_absolute_pathlike("\\share\\foo") is True
+
+    def test_windows_drive(self):
+        assert _is_absolute_pathlike("C:\\Users\\a.md") is True
+        assert _is_absolute_pathlike("D:/tmp/a.md") is True
+
+    def test_tilde(self):
+        assert _is_absolute_pathlike("~/report.md") is True
+
+    def test_relative_simple(self):
+        assert _is_absolute_pathlike("report.md") is False
+
+    def test_relative_nested(self):
+        assert _is_absolute_pathlike("sub/a.md") is False
+
+    def test_relative_dotdot(self):
+        assert _is_absolute_pathlike("../escape.md") is False
+
+    def test_empty(self):
+        assert _is_absolute_pathlike("") is False
+
+
+class TestRewriteFileLinkHrefs:
+    """覆盖 LLM 在 [text](#sensenova-claw-file:PATH) 里写相对路径的场景。"""
+
+    @staticmethod
+    def _workdir() -> str:
+        return str(Path(tempfile.gettempdir()).resolve() / "sensenova_claw_test_workdir")
+
+    def test_rewrites_bare_filename(self):
+        wd = self._workdir()
+        wd_fwd = wd.replace("\\", "/")
+        text = "已生成文件：[自我介绍.md](#sensenova-claw-file:自我介绍.md)"
+        result = rewrite_file_link_hrefs(text, wd)
+        assert f"(#sensenova-claw-file:{wd_fwd}/自我介绍.md)" in result
+
+    def test_rewrites_dot_slash_prefix(self):
+        wd = self._workdir()
+        wd_fwd = wd.replace("\\", "/")
+        text = "[report](#sensenova-claw-file:./out/report.md)"
+        result = rewrite_file_link_hrefs(text, wd)
+        assert f"(#sensenova-claw-file:{wd_fwd}/out/report.md)" in result
+
+    def test_preserves_absolute_posix(self):
+        wd = self._workdir()
+        text = "[x](#sensenova-claw-file:/sandbox/.sensenova-claw/workdir/default/x.md)"
+        result = rewrite_file_link_hrefs(text, wd)
+        assert result == text
+
+    def test_preserves_absolute_windows_drive(self):
+        wd = self._workdir()
+        text = r"[x](#sensenova-claw-file:C:\Users\alice\x.md)"
+        result = rewrite_file_link_hrefs(text, wd)
+        assert result == text
+
+    def test_preserves_tilde(self):
+        wd = self._workdir()
+        text = "[x](#sensenova-claw-file:~/Documents/x.md)"
+        result = rewrite_file_link_hrefs(text, wd)
+        assert result == text
+
+    def test_handles_url_encoded_chinese(self):
+        wd = self._workdir()
+        wd_fwd = wd.replace("\\", "/")
+        encoded = quote("自我介绍.md", safe="")
+        text = f"[x](#sensenova-claw-file:{encoded})"
+        result = rewrite_file_link_hrefs(text, wd)
+        # 输出恢复成原始中文，前端 decodeURIComponent 仍能正常打开
+        assert f"(#sensenova-claw-file:{wd_fwd}/自我介绍.md)" in result
+
+    def test_handles_backslash_relative(self):
+        """Windows 风格反斜杠相对路径：统一转正斜杠。"""
+        wd = self._workdir()
+        wd_fwd = wd.replace("\\", "/")
+        text = r"[x](#sensenova-claw-file:sub\dir\x.md)"
+        result = rewrite_file_link_hrefs(text, wd)
+        assert f"(#sensenova-claw-file:{wd_fwd}/sub/dir/x.md)" in result
+
+    def test_normalizes_dotdot(self):
+        wd = self._workdir()
+        wd_fwd = wd.replace("\\", "/")
+        text = "[x](#sensenova-claw-file:sub/../x.md)"
+        result = rewrite_file_link_hrefs(text, wd)
+        assert f"(#sensenova-claw-file:{wd_fwd}/x.md)" in result
+
+    def test_empty_workdir_keeps_original(self):
+        """agent 在开发机/非沙箱场景可能没有 workdir，不得误改。"""
+        text = "[x](#sensenova-claw-file:report.md)"
+        assert rewrite_file_link_hrefs(text, "") == text
+        assert rewrite_file_link_hrefs(text, None) == text  # type: ignore[arg-type]
+
+    def test_empty_content(self):
+        assert rewrite_file_link_hrefs("", self._workdir()) == ""
+
+    def test_empty_href_left_as_is(self):
+        wd = self._workdir()
+        text = "[x](#sensenova-claw-file:)"
+        assert rewrite_file_link_hrefs(text, wd) == text
+
+    def test_ignores_workdir_prefix_link(self):
+        """#sensenova-claw-workdir: 前端要求相对路径，不能改写。"""
+        wd = self._workdir()
+        text = "[slides](#sensenova-claw-workdir:my-ppt/page_01.html)"
+        assert rewrite_file_link_hrefs(text, wd) == text
+
+    def test_leaves_plain_markdown_link_untouched(self):
+        wd = self._workdir()
+        text = "参考 [repo](https://github.com/foo/bar) 和 [doc](./a.md)"
+        assert rewrite_file_link_hrefs(text, wd) == text
+
+    def test_multiple_links_in_one_message(self):
+        wd = self._workdir()
+        wd_fwd = wd.replace("\\", "/")
+        text = (
+            "[a.md](#sensenova-claw-file:a.md) 和 "
+            "[b.md](#sensenova-claw-file:sub/b.md)"
+        )
+        result = rewrite_file_link_hrefs(text, wd)
+        assert f"(#sensenova-claw-file:{wd_fwd}/a.md)" in result
+        assert f"(#sensenova-claw-file:{wd_fwd}/sub/b.md)" in result
+
+    def test_combined_with_code_span_rewrite(self):
+        """两个函数串联：inline code + link href 各管一边。"""
+        wd = self._workdir()
+        wd_fwd = wd.replace("\\", "/")
+        text = (
+            "已生成 [自我介绍.md](#sensenova-claw-file:自我介绍.md)\n"
+            "位置: `自我介绍.md`"
+        )
+        step1 = rewrite_relative_paths(text, wd)
+        step2 = rewrite_file_link_hrefs(step1, wd)
+        assert f"`{wd_fwd}/自我介绍.md`" in step2
+        assert f"(#sensenova-claw-file:{wd_fwd}/自我介绍.md)" in step2


### PR DESCRIPTION
## Summary

  修复「对话气泡里文件链接 → 点击 → 预览/定位」这条端到端链路的两个断点。

  ### 1. 后端：`path_rewriter` 新增 file link href 归一化

  LLM 在生成 `[text](#sensenova-claw-file:PATH)` 时经常给出相对路径（例如 `reports/foo.md`），前端拿到后直接走 `/api/files/download?path=...` 命中
  path_policy 校验失败，点击就没反应。

  - `sensenova_claw/kernel/runtime/path_rewriter.py`：新增 `rewrite_file_link_hrefs(content, workdir)`，仅处理 `#sensenova-claw-file:`
  前缀的链接；已绝对（POSIX / Windows 盘符 / `~`）的不动，反斜杠统一成 `/`，兼容 URL 编码。
  - `sensenova_claw/kernel/runtime/workers/agent_worker.py`：在把 LLM 输出回传给前端前调用归一化。
  - 覆盖单测：`tests/unit/test_path_rewriter.py` 新增 11 个 case（绝对路径不动、相对路径拼接、Windows 盘符、`~`、URL 编码、workdir 为空 fallback 等）。

  ### 2. 前端：`/chat` 页面接入 `open-file-preview` 事件

  `components/chat/ChatPanel.tsx` 一直有 `open-file-preview` 监听 + `<InlinePreview/>` 渲染，但 `app/chat/page.tsx` 是另一套独立入口，只接了 slide
  预览，**漏接了 file 预览**。结果：chip 点击走 `openToPath` Context 能让文件区高亮生效，但对话区预览不渲染。

  - `sensenova_claw/app/web/app/chat/page.tsx`
    - 新增 `filePreview` state + `open-file-preview` window 监听
    - 两种预览互斥：触发 file preview 时清 slide，反之亦然
    - 切换 session 时清空两者
    - 用 `<InlinePreview/>` 替换内联的 `SlideViewer`，和 `ChatPanel` 保持一致
    - 清掉随之失效的 `dynamic` 动态导入

  改成复用 `InlinePreview` 之后，以后任何新加的 chat 类页面只要用这个组件，预览事件就不会再漏接。
