### PR TITLE
fix: 修复 Windows 路径下 file-chip 点击 404 与相关跨平台路径 bug

### DIFF
--- a/sensenova_claw/app/web/components/ui/Markdown.tsx
+++ b/sensenova_claw/app/web/components/ui/Markdown.tsx
@@ -188,6 +188,7 @@ export const Markdown = memo(function Markdown({ content, className, variant = '
           <a
             href="#"
             onClick={handleClick}
+            title={filePath}
             className="inline-flex items-center gap-1.5 px-2.5 py-1 my-0.5 rounded-lg bg-primary/10 text-primary hover:bg-primary/20 transition-colors text-sm font-medium no-underline border border-primary/20 cursor-pointer"
             {...props}
           >
@@ -210,6 +211,7 @@ export const Markdown = memo(function Markdown({ content, className, variant = '
           <a
             href="#"
             onClick={handleClick}
+            title={relPath}
             className="inline-flex items-center gap-1.5 px-2.5 py-1 my-0.5 rounded-lg bg-orange-500/10 text-orange-600 dark:text-orange-400 hover:bg-orange-500/20 transition-colors text-sm font-medium no-underline border border-orange-500/20 cursor-pointer"
             {...props}
           >

--- a/sensenova_claw/kernel/runtime/path_rewriter.py
+++ b/sensenova_claw/kernel/runtime/path_rewriter.py
@@ -194,18 +194,26 @@ def rewrite_relative_paths(content: str, workdir: str) -> str:
     return _CODE_SPAN_RE.sub(_replace, content)
 
 
-def encode_file_link_parens(content: str) -> str:
-    """把 ``#sensenova-claw-file:`` href 中的未转义括号做 URL 编码。
+def sanitize_file_link_href(content: str) -> str:
+    """规避 markdown link destination 中对 ``#sensenova-claw-file:`` href 的错误解析。
 
-    **存在的原因**：Windows 常见路径 ``C:\\Program Files (x86)\\...`` 里
-    带未转义的 ``(``/``)``，会把 markdown link 语法拦腰切断 —— 不只是
-    本模块的正则，前端 react-markdown / remark-gfm 也会在第一个 ``)``
-    处结束 link，导致 chip 的 href 被截短，点击必然 404。
+    两类字符会被 markdown parser 误处理，必须在 LLM 输出落地前转写：
 
-    **做法**：先用支持一层 ``(...)`` 嵌套的平衡正则定位完整 href，然后
-    把 body 中所有 ``(``/``)`` 替换成 ``%28``/``%29``。后续 markdown
-    解析和 ``rewrite_file_link_hrefs`` 都能正常工作；前端
-    ``decodeURIComponent`` 会把它们还原成真正的括号显示给用户。
+    - **未转义的 ``(`` / ``)``**：Windows 典型路径 ``C:\\Program Files (x86)\\...``
+      里带裸括号，虽然 CommonMark 允许一层 balanced parens，但多种渲染器
+      （包括本模块正则和前端 react-markdown）在嵌套/配对失衡时会在第一个
+      ``)`` 处截断 link，href 缺尾，点击必 404。替换为 ``%28`` / ``%29``。
+    - **反斜杠 + ASCII 标点（``\\.``、``\\_``、``\\-`` 等）**：CommonMark 把
+      link destination 中的 ``\\ + 标点`` 识别为 backslash-escape，反斜杠
+      被吃掉。Windows 路径 ``C:\\Users\\foo\\.sensenova-claw\\...`` 里的
+      ``\\.`` 会退化成 ``.``，得到 ``C:\\Users\\foo.sensenova-claw\\...``
+      这种少一级分隔符的错误路径，下游 ``/api/files/download`` 必然 404。
+      做法：把 href body 中所有 ``\\`` 统一换成 ``/``。Windows Python
+      ``Path`` 同时接受 ``/`` / ``\\``，语义无损；下游匹配走 ``norm()`` 再
+      归一，不会因分隔符差异失败。
+
+    用支持一层 ``(...)`` 平衡嵌套的正则定位完整 href，后续
+    ``rewrite_file_link_hrefs`` 与前端 ``decodeURIComponent`` 均能正常工作。
     """
     if not content:
         return content
@@ -214,12 +222,20 @@ def encode_file_link_parens(content: str) -> str:
         prefix = match.group(1)
         body = match.group(2)
         suffix = match.group(3)
-        if "(" not in body and ")" not in body:
+        if "(" not in body and ")" not in body and "\\" not in body:
             return match.group(0)
-        encoded = body.replace("(", "%28").replace(")", "%29")
-        return f"{prefix}{encoded}{suffix}"
+        sanitized = (
+            body.replace("\\", "/")
+                .replace("(", "%28")
+                .replace(")", "%29")
+        )
+        return f"{prefix}{sanitized}{suffix}"
 
     return _FILE_LINK_RE.sub(_replace, content)
+
+
+# 保留旧名作为别名，避免外部 import 失败（过渡期，后续可移除）
+encode_file_link_parens = sanitize_file_link_href
 
 
 def rewrite_file_link_hrefs(content: str, workdir: str) -> str:

--- a/sensenova_claw/kernel/runtime/path_rewriter.py
+++ b/sensenova_claw/kernel/runtime/path_rewriter.py
@@ -3,23 +3,32 @@
 模型在回复用户时经常使用相对路径（如 `report.md`、`./output/data.csv`），
 用户看到后无法直接定位文件。此模块在发送给前端之前，将文本中可识别的
 相对路径改写为基于 agent workdir 的绝对路径。
+
+跨平台注意：LLM 与后端运行宿主的平台组合是正交的（Windows 后端处理
+POSIX 路径、Linux 后端处理 Windows 路径都要兼容），因此本模块不依赖
+``pathlib.Path`` 的运行时平台行为，统一以正斜杠 + 手写盘符处理为规范。
 """
 
 from __future__ import annotations
 
+import os
 import posixpath
 import re
-from pathlib import Path, PurePosixPath
+from pathlib import Path
 from urllib.parse import unquote
 
 
 # 匹配 Markdown 行内代码 `...` 中包含的文件路径
 _CODE_SPAN_RE = re.compile(r"`([^`]+)`")
 
-# 匹配 [text](#sensenova-claw-file:PATH) 形式的文件链接
-# 前端 Markdown.tsx 以此前缀识别并渲染成可点击卡片；PATH 由 LLM 产出，
-# 常因路径规则理解偏差出现相对形式，导致点击打开失败。
-_FILE_LINK_RE = re.compile(r"(\]\(#sensenova-claw-file:)([^)]*?)(\))")
+# 匹配 [text](#sensenova-claw-file:PATH) 形式的文件链接。
+# PATH 允许包含一层 ``(...)`` 嵌套（典型例子：``C:\Program Files (x86)\foo.md``），
+# 再深的嵌套在实际路径里极罕见，且 markdown 规范本身也要求 URL 里对 ``)`` 做转义。
+_FILE_LINK_RE = re.compile(
+    r"(\]\(#sensenova-claw-file:)"
+    r"((?:[^)(]|\([^)(]*\))*)"
+    r"(\))"
+)
 
 # 常见文件扩展名，用于判定是否像一个文件路径
 _FILE_EXTENSIONS = {
@@ -30,61 +39,6 @@ _FILE_EXTENSIONS = {
     ".sh", ".bash", ".bat", ".ps1", ".log", ".xml", ".toml",
     ".env", ".cfg", ".ini", ".sql", ".r", ".ipynb",
 }
-
-
-def _looks_like_relative_file_path(text: str) -> bool:
-    """判断 text 是否看起来像一个相对文件路径（而非代码片段、URL、命令等）。"""
-    text = text.strip()
-    if not text:
-        return False
-    # 排除 URL
-    if text.startswith(("http://", "https://", "ftp://", "data:")):
-        return False
-    # 排除已是绝对路径（Unix / Windows）
-    if text.startswith("/") or text.startswith("~"):
-        return False
-    if len(text) >= 3 and text[1] == ":" and text[2] in ("/", "\\"):
-        return False
-    # 排除纯变量名/单词（无路径分隔符也无扩展名）
-    # 排除包含空格但无路径分隔符的（更像自然语言）
-    # 获取扩展名
-    try:
-        suffix = PurePosixPath(text).suffix.lower()
-    except Exception:
-        suffix = ""
-    # 必须有已知扩展名才认定为文件路径
-    if not suffix or suffix not in _FILE_EXTENSIONS:
-        return False
-    # 排除太长的字符串（不太像路径）
-    if len(text) > 200:
-        return False
-    # 排除含有明显非路径字符
-    if any(c in text for c in ("(", ")", "{", "}", "<", ">", "|", ";", "&", "=", "?")):
-        return False
-    return True
-
-
-def rewrite_relative_paths(content: str, workdir: str) -> str:
-    """将 assistant 回复文本中 `...` 引用的相对路径改写为绝对路径。
-
-    仅处理 Markdown 行内代码块 `...` 中的内容，避免误改自然语言。
-    """
-    if not content or not workdir:
-        return content
-
-    workdir_resolved = str(Path(workdir).resolve())
-
-    def _replace(match: re.Match) -> str:
-        raw = match.group(1)
-        if not _looks_like_relative_file_path(raw):
-            return match.group(0)
-        # 构建绝对路径
-        abs_path = str((Path(workdir_resolved) / raw).resolve())
-        # 统一使用正斜杠（跨平台友好）
-        abs_path = abs_path.replace("\\", "/")
-        return f"`{abs_path}`"
-
-    return _CODE_SPAN_RE.sub(_replace, content)
 
 
 def _is_absolute_pathlike(text: str) -> bool:
@@ -114,6 +68,160 @@ def _is_absolute_pathlike(text: str) -> bool:
     return False
 
 
+def _split_drive(text: str) -> tuple[str, str]:
+    """分离 Windows 盘符前缀，返回 ``(drive, rest)``。
+
+    - ``"C:/foo"`` → ``("C:", "/foo")``
+    - ``"C:\\foo"`` → ``("C:", "/foo")``（调用方应先做反斜杠归一）
+    - ``"/foo"``   → ``("", "/foo")``
+    - ``"foo"``    → ``("", "foo")``
+
+    仅识别 ``<letter>:/`` 或 ``<letter>:\\`` 形式。``C:relative`` 这种
+    无分隔符的 Windows 旧式写法（极罕见）不视为盘符，保持和
+    ``_is_absolute_pathlike`` 一致。
+    """
+    if (
+        len(text) >= 3
+        and text[0].isalpha()
+        and text[1] == ":"
+        and text[2] in ("/", "\\")
+    ):
+        return text[:2], text[2:]
+    return "", text
+
+
+def _join_and_normalize(workdir_abs: str, relative: str) -> str:
+    """拼接绝对 workdir 与相对路径并规范化 ``.``/``..``。
+
+    关键差异 vs. ``posixpath.normpath("C:/sandbox/../../x")``:
+    - ``posixpath`` 不认识 ``C:``，会把盘符当作一级目录被 ``..`` 吃掉，
+      得到 ``"x"`` — 盘符丢失，语义错乱，还可能绕过下游路径白名单。
+    - 此函数先剥离盘符，对剩余部分以 ``/`` 为根做规范化，``..`` 最多
+      退到盘符根（``"/"``），然后拼回盘符前缀。
+
+    假设 ``workdir_abs`` 已经过 ``_normalize_workdir`` 处理：使用正斜杠、
+    盘符形如 ``"C:"``、根以 ``/`` 起始。``relative`` 可以含反斜杠，内部
+    统一转正斜杠。
+    """
+    drive, root = _split_drive(workdir_abs)
+    if not root.startswith("/"):
+        # workdir 已被 _normalize_workdir 保证绝对，这里是兜底
+        root = "/" + root
+    rel = relative.replace("\\", "/")
+    joined = posixpath.join(root, rel)
+    normalized = posixpath.normpath(joined)
+    return drive + normalized
+
+
+def _normalize_workdir(workdir: str) -> str:
+    """把 workdir 归一为正斜杠绝对路径，且不依赖宿主 Path 的平台行为。
+
+    - 若 ``workdir`` 已是绝对路径（POSIX / Windows 盘符 / UNC ``\\\\server``），
+      直接做字符串归一，**不调用 ``Path.resolve()``**。这能避免 Windows
+      宿主处理 ``/home/user/work`` 时被当作"当前盘符下的目录"拼出
+      ``C:\\home\\user\\work`` 的错误。
+    - ``~`` 用 ``os.path.expanduser`` 展开（POSIX 上展开为 ``$HOME``，
+      Windows 上展开为用户 Profile）。
+    - 相对 workdir（少见；通常来自配置误写）仍走 ``Path.resolve()`` 拼
+      当前 CWD —— 这部分行为无法跨平台做得比宿主 Path 更好。
+    """
+    if not workdir:
+        return ""
+    expanded = os.path.expanduser(workdir)
+    if _is_absolute_pathlike(expanded):
+        unified = expanded.replace("\\", "/")
+        drive, rest = _split_drive(unified)
+        if not rest.startswith("/"):
+            rest = "/" + rest
+        return drive + posixpath.normpath(rest)
+    # 相对路径：只能依赖宿主解析
+    try:
+        return str(Path(expanded).resolve()).replace("\\", "/")
+    except (OSError, ValueError):
+        return expanded.replace("\\", "/")
+
+
+def _looks_like_relative_file_path(text: str) -> bool:
+    """判断 text 是否看起来像一个相对文件路径（而非代码片段、URL、命令等）。"""
+    text = text.strip()
+    if not text:
+        return False
+    # 排除 URL
+    if text.startswith(("http://", "https://", "ftp://", "data:")):
+        return False
+    # 排除已是绝对路径（Unix / Windows）
+    if _is_absolute_pathlike(text):
+        return False
+    # 判断扩展名时先归一反斜杠，避免 ``docs\a.md`` 在 POSIX 上被拆不出后缀
+    unified = text.replace("\\", "/")
+    # 获取扩展名
+    suffix = posixpath.splitext(unified)[1].lower()
+    # 必须有已知扩展名才认定为文件路径
+    if not suffix or suffix not in _FILE_EXTENSIONS:
+        return False
+    # 排除太长的字符串（不太像路径）
+    if len(text) > 200:
+        return False
+    # 排除含有明显非路径字符（注意：``(`` / ``)`` 在 Windows 路径中合法，
+    # 此处扫描的是 inline code span，里面若出现括号更可能是代码调用，
+    # 因此仍保留排除）
+    if any(c in text for c in ("(", ")", "{", "}", "<", ">", "|", ";", "&", "=", "?")):
+        return False
+    return True
+
+
+def rewrite_relative_paths(content: str, workdir: str) -> str:
+    """将 assistant 回复文本中 `...` 引用的相对路径改写为绝对路径。
+
+    仅处理 Markdown 行内代码块 `...` 中的内容，避免误改自然语言。
+    内部统一走 ``_join_and_normalize``，保证与 ``rewrite_file_link_hrefs``
+    在跨平台场景下的输出一致。
+    """
+    if not content or not workdir:
+        return content
+
+    workdir_abs = _normalize_workdir(workdir)
+    if not workdir_abs:
+        return content
+
+    def _replace(match: re.Match) -> str:
+        raw = match.group(1)
+        if not _looks_like_relative_file_path(raw):
+            return match.group(0)
+        abs_path = _join_and_normalize(workdir_abs, raw.strip())
+        return f"`{abs_path}`"
+
+    return _CODE_SPAN_RE.sub(_replace, content)
+
+
+def encode_file_link_parens(content: str) -> str:
+    """把 ``#sensenova-claw-file:`` href 中的未转义括号做 URL 编码。
+
+    **存在的原因**：Windows 常见路径 ``C:\\Program Files (x86)\\...`` 里
+    带未转义的 ``(``/``)``，会把 markdown link 语法拦腰切断 —— 不只是
+    本模块的正则，前端 react-markdown / remark-gfm 也会在第一个 ``)``
+    处结束 link，导致 chip 的 href 被截短，点击必然 404。
+
+    **做法**：先用支持一层 ``(...)`` 嵌套的平衡正则定位完整 href，然后
+    把 body 中所有 ``(``/``)`` 替换成 ``%28``/``%29``。后续 markdown
+    解析和 ``rewrite_file_link_hrefs`` 都能正常工作；前端
+    ``decodeURIComponent`` 会把它们还原成真正的括号显示给用户。
+    """
+    if not content:
+        return content
+
+    def _replace(match: re.Match) -> str:
+        prefix = match.group(1)
+        body = match.group(2)
+        suffix = match.group(3)
+        if "(" not in body and ")" not in body:
+            return match.group(0)
+        encoded = body.replace("(", "%28").replace(")", "%29")
+        return f"{prefix}{encoded}{suffix}"
+
+    return _FILE_LINK_RE.sub(_replace, content)
+
+
 def rewrite_file_link_hrefs(content: str, workdir: str) -> str:
     """将 ``[text](#sensenova-claw-file:PATH)`` 中非绝对的 PATH 拼成绝对路径。
 
@@ -123,23 +231,20 @@ def rewrite_file_link_hrefs(content: str, workdir: str) -> str:
       或未配置 workdir，此时强行拼接反而误导）。
     - **PATH 已是绝对形式**：不改（POSIX / Windows 盘符 / ``~`` 三种）。
     - **反斜杠归一**：Python 在 POSIX 上不把 ``\\`` 当分隔符，因此先把
-      ``\\`` 替换为 ``/``，再用 ``posixpath.normpath`` 统一处理
-      ``.``、``..``、冗余斜杠。拒绝依赖当前运行平台的 Path 行为。
+      ``\\`` 替换为 ``/``；再走 ``_join_and_normalize`` 处理 ``.``/``..``
+      与 Windows 盘符边界。拒绝依赖当前运行平台的 Path 行为。
     - **URL 编码兼容**：LLM 多数直接写原始路径，也可能产出百分号编码；
       ``unquote`` 对普通文本是 no-op，对编码文本能正确解码。
       输出统一用解码后的原始路径，前端 ``decodeURIComponent`` 仍是 no-op。
-    - **安全边界**：越出 workdir 的 ``..`` 组合会按字面规范化，不会额外
-      阻断；下游 ``/api/files/download`` 自带 path_policy 校验，这里
-      只负责语义归一。
+    - **安全边界**：越出 workdir 的 ``..`` 组合在盘符根/根目录处停住
+      （不会把 ``C:`` 吃掉导致路径退化），下游 ``/api/files/download``
+      自带 path_policy 校验，这里只负责语义归一。
     """
     if not content or not workdir:
         return content
 
-    try:
-        # 统一以正斜杠作为输出分隔符，避免 Windows ``\\`` 进入 markdown 后被
-        # 下游 ``decodeURIComponent`` 或 URL 解析误判。
-        workdir_abs = str(Path(workdir).expanduser().resolve()).replace("\\", "/")
-    except Exception:
+    workdir_abs = _normalize_workdir(workdir)
+    if not workdir_abs:
         return content
 
     def _replace(match: re.Match) -> str:
@@ -155,11 +260,7 @@ def rewrite_file_link_hrefs(content: str, workdir: str) -> str:
         if not decoded or _is_absolute_pathlike(decoded):
             return match.group(0)
 
-        normalized = decoded.replace("\\", "/")
-        # PurePosixPath 保证在任意宿主平台上的行为一致
-        joined = str(PurePosixPath(workdir_abs) / normalized)
-        abs_path = posixpath.normpath(joined)
-
+        abs_path = _join_and_normalize(workdir_abs, decoded)
         return f"{prefix}{abs_path}{suffix}"
 
     return _FILE_LINK_RE.sub(_replace, content)

--- a/sensenova_claw/kernel/runtime/workers/agent_worker.py
+++ b/sensenova_claw/kernel/runtime/workers/agent_worker.py
@@ -585,15 +585,17 @@ class AgentSessionWorker(SessionWorker):
         # 后处理：将回复中的相对路径改写为绝对路径
         from sensenova_claw.platform.config.workspace import resolve_agent_workdir, resolve_sensenova_claw_home
         from sensenova_claw.kernel.runtime.path_rewriter import (
-            encode_file_link_parens,
             rewrite_file_link_hrefs,
             rewrite_relative_paths,
+            sanitize_file_link_href,
         )
         _home = str(resolve_sensenova_claw_home(config))
         _workdir = resolve_agent_workdir(_home, self.agent_config)
-        # 先把 file-link href 里未转义的括号编码，避免 `C:\Program Files (x86)\...`
-        # 这类 Windows 路径被 markdown parser 或后续正则截断。
-        content = encode_file_link_parens(content)
+        # 先把 file-link href 里会被 markdown 误解的字符规避（括号 + 反斜杠）：
+        # - `C:\Program Files (x86)\...` 的 `(` `)` 会截断 link
+        # - `C:\Users\foo\.sensenova-claw\...` 的 `\.` `\_` 会被 backslash-escape
+        #   吃掉反斜杠，得到少一级分隔符的错误路径
+        content = sanitize_file_link_href(content)
         content = rewrite_relative_paths(content, _workdir)
         # 文件卡片 href（#sensenova-claw-file:）里 LLM 可能塞相对路径，
         # 前端点击会 404。此处与 inline code 规范化互补。

--- a/sensenova_claw/kernel/runtime/workers/agent_worker.py
+++ b/sensenova_claw/kernel/runtime/workers/agent_worker.py
@@ -585,11 +585,15 @@ class AgentSessionWorker(SessionWorker):
         # 后处理：将回复中的相对路径改写为绝对路径
         from sensenova_claw.platform.config.workspace import resolve_agent_workdir, resolve_sensenova_claw_home
         from sensenova_claw.kernel.runtime.path_rewriter import (
+            encode_file_link_parens,
             rewrite_file_link_hrefs,
             rewrite_relative_paths,
         )
         _home = str(resolve_sensenova_claw_home(config))
         _workdir = resolve_agent_workdir(_home, self.agent_config)
+        # 先把 file-link href 里未转义的括号编码，避免 `C:\Program Files (x86)\...`
+        # 这类 Windows 路径被 markdown parser 或后续正则截断。
+        content = encode_file_link_parens(content)
         content = rewrite_relative_paths(content, _workdir)
         # 文件卡片 href（#sensenova-claw-file:）里 LLM 可能塞相对路径，
         # 前端点击会 404。此处与 inline code 规范化互补。

--- a/tests/unit/test_path_rewriter.py
+++ b/tests/unit/test_path_rewriter.py
@@ -7,7 +7,11 @@ from urllib.parse import quote
 
 from sensenova_claw.kernel.runtime.path_rewriter import (
     _is_absolute_pathlike,
+    _join_and_normalize,
     _looks_like_relative_file_path,
+    _normalize_workdir,
+    _split_drive,
+    encode_file_link_parens,
     rewrite_file_link_hrefs,
     rewrite_relative_paths,
 )
@@ -276,3 +280,194 @@ class TestRewriteFileLinkHrefs:
         step2 = rewrite_file_link_hrefs(step1, wd)
         assert f"`{wd_fwd}/自我介绍.md`" in step2
         assert f"(#sensenova-claw-file:{wd_fwd}/自我介绍.md)" in step2
+
+
+class TestSplitDrive:
+    def test_forward_slash_drive(self):
+        assert _split_drive("C:/foo") == ("C:", "/foo")
+
+    def test_backslash_drive(self):
+        assert _split_drive("D:\\foo\\bar") == ("D:", "\\foo\\bar")
+
+    def test_no_drive_posix(self):
+        assert _split_drive("/home/user") == ("", "/home/user")
+
+    def test_no_drive_relative(self):
+        assert _split_drive("foo/bar") == ("", "foo/bar")
+
+    def test_colon_without_separator_not_drive(self):
+        # `C:foo` 这种无分隔符形式不当作盘符（和 _is_absolute_pathlike 一致）
+        assert _split_drive("C:foo") == ("", "C:foo")
+
+    def test_empty(self):
+        assert _split_drive("") == ("", "")
+
+
+class TestNormalizeWorkdir:
+    def test_posix_absolute_unchanged(self):
+        # 即使在 Windows 宿主跑到这里，也不得拼当前盘符
+        assert _normalize_workdir("/home/user/work") == "/home/user/work"
+
+    def test_windows_drive_forward_slash(self):
+        assert _normalize_workdir("C:/sandbox/work") == "C:/sandbox/work"
+
+    def test_windows_drive_backslash(self):
+        assert _normalize_workdir("C:\\sandbox\\work") == "C:/sandbox/work"
+
+    def test_empty(self):
+        assert _normalize_workdir("") == ""
+
+    def test_dotdot_normalized(self):
+        assert _normalize_workdir("C:/sandbox/../work") == "C:/work"
+
+    def test_trailing_slash_trimmed(self):
+        # posixpath.normpath 会去掉尾部 /（保留根目录 / 本身）
+        assert _normalize_workdir("/a/b/") == "/a/b"
+
+
+class TestJoinAndNormalize:
+    """核心断言：Windows 盘符不能被 .. 吃掉。"""
+
+    def test_simple_join_posix(self):
+        assert _join_and_normalize("/sandbox", "a.md") == "/sandbox/a.md"
+
+    def test_simple_join_windows(self):
+        assert _join_and_normalize("C:/sandbox", "a.md") == "C:/sandbox/a.md"
+
+    def test_dotdot_stops_at_root_posix(self):
+        # POSIX 根目录上 .. 不会退出根
+        assert _join_and_normalize("/sandbox", "../../../a.md") == "/a.md"
+
+    def test_dotdot_stops_at_drive_root_windows(self):
+        # 关键 Bug A 回归：.. 越界应停在盘符根，而不是把盘符吃掉
+        result = _join_and_normalize("C:/sandbox", "../../../Windows/System32/x.txt")
+        assert result == "C:/Windows/System32/x.txt"
+        # 对比 posixpath.normpath 原生行为（会退化成 "Windows/System32/x.txt"）
+        assert result.startswith("C:")
+
+    def test_backslash_relative_normalized(self):
+        # Bug C：反斜杠形式的相对路径要归一
+        assert _join_and_normalize("/sandbox", "sub\\dir\\a.md") == "/sandbox/sub/dir/a.md"
+
+    def test_backslash_relative_with_drive(self):
+        assert (
+            _join_and_normalize("C:/sandbox", "sub\\dir\\a.md")
+            == "C:/sandbox/sub/dir/a.md"
+        )
+
+    def test_dot_slash_prefix(self):
+        assert _join_and_normalize("/sandbox", "./a.md") == "/sandbox/a.md"
+
+    def test_nested_dotdot_inside_workdir(self):
+        # workdir 内合法的 .. 仍然能走
+        assert _join_and_normalize("/sandbox/a/b", "../c.md") == "/sandbox/a/c.md"
+
+
+class TestRewriteFileLinkHrefsWindows:
+    """Bug A/C/D 在 file link 场景下的回归。"""
+
+    def test_dotdot_cannot_eat_windows_drive(self):
+        """Bug A：.. 越界时盘符必须保留。"""
+        text = "[x](#sensenova-claw-file:../../../Windows/System32/x.txt)"
+        result = rewrite_file_link_hrefs(text, "C:/sandbox")
+        assert "(#sensenova-claw-file:C:/Windows/System32/x.txt)" in result
+        # 保证输出没有退化成相对路径
+        assert "(#sensenova-claw-file:Windows/" not in result
+
+    def test_backslash_workdir_input(self):
+        """Bug D：workdir 传入 Windows 反斜杠形式也能正常归一。"""
+        text = "[x](#sensenova-claw-file:a.md)"
+        result = rewrite_file_link_hrefs(text, "C:\\sandbox\\work")
+        assert "(#sensenova-claw-file:C:/sandbox/work/a.md)" in result
+
+    def test_posix_workdir_not_prefixed_with_drive(self):
+        """Bug D：宿主是 Windows 时，传入 POSIX 风格 workdir 也不该被拼盘符。
+
+        模拟：_normalize_workdir 直接走字符串归一分支。
+        """
+        text = "[x](#sensenova-claw-file:a.md)"
+        result = rewrite_file_link_hrefs(text, "/home/user/work")
+        assert "(#sensenova-claw-file:/home/user/work/a.md)" in result
+        # 不应出现任何 <letter>: 盘符前缀
+        import re as _re
+        assert not _re.search(r"#sensenova-claw-file:[A-Za-z]:", result)
+
+    def test_dotdot_cannot_escape_posix_root(self):
+        """越界回退到 POSIX 根，不影响下游白名单。"""
+        text = "[x](#sensenova-claw-file:../../../etc/passwd)"
+        result = rewrite_file_link_hrefs(text, "/sandbox/work")
+        # 退到根目录，但不丢前导 /
+        assert "(#sensenova-claw-file:/etc/passwd)" in result
+
+
+class TestEncodeFileLinkParens:
+    """Bug B：Windows 路径中未转义的 () 必须被编码，避免 markdown 截断。"""
+
+    def test_program_files_x86(self):
+        text = "[foo](#sensenova-claw-file:C:/Program Files (x86)/foo.md)"
+        result = encode_file_link_parens(text)
+        assert (
+            "[foo](#sensenova-claw-file:C:/Program Files %28x86%29/foo.md)" in result
+        )
+
+    def test_no_parens_no_change(self):
+        text = "[foo](#sensenova-claw-file:/sandbox/a.md)"
+        assert encode_file_link_parens(text) == text
+
+    def test_multiple_file_links(self):
+        text = (
+            "[a](#sensenova-claw-file:a.md) 和 "
+            "[b](#sensenova-claw-file:Files (x86)/b.md)"
+        )
+        result = encode_file_link_parens(text)
+        assert "[a](#sensenova-claw-file:a.md)" in result
+        assert "[b](#sensenova-claw-file:Files %28x86%29/b.md)" in result
+
+    def test_workdir_prefix_not_touched(self):
+        # 只编码 file 前缀，workdir 前缀维持原样
+        text = "[slides](#sensenova-claw-workdir:my-ppt (draft)/page.html)"
+        assert encode_file_link_parens(text) == text
+
+    def test_plain_link_not_touched(self):
+        text = "参考 [wiki](https://en.wikipedia.org/wiki/Foo_(bar))"
+        assert encode_file_link_parens(text) == text
+
+    def test_combined_with_rewrite(self):
+        """关键场景：含括号的 Windows 路径能完整走完 encode → rewrite 链路。"""
+        text = "[报告](#sensenova-claw-file:Program Files (x86)/report.md)"
+        step1 = encode_file_link_parens(text)
+        step2 = rewrite_file_link_hrefs(step1, "C:/sandbox")
+        assert (
+            "(#sensenova-claw-file:C:/sandbox/Program Files %28x86%29/report.md)"
+            in step2
+        )
+
+    def test_empty_content(self):
+        assert encode_file_link_parens("") == ""
+
+
+class TestRewriteRelativePathsWindows:
+    """inline code span 的跨平台路径回归。"""
+
+    def test_backslash_relative_in_posix_workdir(self):
+        """Bug C：POSIX 后端处理 Windows 风格反斜杠路径也要归一。"""
+        wd = "/sandbox/work"
+        text = "结果在 `docs\\report.md`"
+        result = rewrite_relative_paths(text, wd)
+        assert "`/sandbox/work/docs/report.md`" in result
+
+    def test_drive_root_escape_stops_at_drive(self):
+        """Bug A：inline code span 的 .. 越界同样要保留盘符。"""
+        wd = "C:/sandbox"
+        text = "这个文件 `../../../Windows/System32/x.txt`"
+        result = rewrite_relative_paths(text, wd)
+        # 由于 () 被排除在"路径样"判定外，这里用简单的 ../ 链
+        # _looks_like_relative_file_path 会识别 .txt → 触发改写
+        assert "`C:/Windows/System32/x.txt`" in result
+
+    def test_posix_workdir_on_windows_host(self):
+        """Bug D：用 POSIX 风格 workdir 不应被拼盘符。"""
+        wd = "/home/user/work"
+        text = "文件在 `report.md`"
+        result = rewrite_relative_paths(text, wd)
+        assert "`/home/user/work/report.md`" in result

--- a/tests/unit/test_path_rewriter.py
+++ b/tests/unit/test_path_rewriter.py
@@ -11,9 +11,9 @@ from sensenova_claw.kernel.runtime.path_rewriter import (
     _looks_like_relative_file_path,
     _normalize_workdir,
     _split_drive,
-    encode_file_link_parens,
     rewrite_file_link_hrefs,
     rewrite_relative_paths,
+    sanitize_file_link_href,
 )
 
 
@@ -400,50 +400,90 @@ class TestRewriteFileLinkHrefsWindows:
         assert "(#sensenova-claw-file:/etc/passwd)" in result
 
 
-class TestEncodeFileLinkParens:
-    """Bug B：Windows 路径中未转义的 () 必须被编码，避免 markdown 截断。"""
+class TestSanitizeFileLinkHref:
+    """Bug B：规避 markdown link destination 对 href 的两类误解析。"""
 
     def test_program_files_x86(self):
         text = "[foo](#sensenova-claw-file:C:/Program Files (x86)/foo.md)"
-        result = encode_file_link_parens(text)
+        result = sanitize_file_link_href(text)
         assert (
             "[foo](#sensenova-claw-file:C:/Program Files %28x86%29/foo.md)" in result
         )
 
-    def test_no_parens_no_change(self):
+    def test_backslash_turns_into_slash(self):
+        """Windows 反斜杠必须归一为 /，否则 markdown 会把 \\.、\\_ 等吃掉反斜杠。"""
+        text = (
+            "[x](#sensenova-claw-file:"
+            "C:\\Users\\zhengjieli1\\.sensenova-claw\\workdir\\default\\a.md)"
+        )
+        result = sanitize_file_link_href(text)
+        assert (
+            "(#sensenova-claw-file:"
+            "C:/Users/zhengjieli1/.sensenova-claw/workdir/default/a.md)"
+        ) in result
+        # 关键防回归：任何 \. 或 \_ 序列都不允许残留在 href 里
+        href_segment = result.split("(#sensenova-claw-file:", 1)[1].split(")", 1)[0]
+        assert "\\" not in href_segment
+
+    def test_backslash_and_parens_together(self):
+        text = (
+            "[x](#sensenova-claw-file:"
+            "C:\\Program Files (x86)\\.app\\run.bat)"
+        )
+        result = sanitize_file_link_href(text)
+        assert (
+            "(#sensenova-claw-file:"
+            "C:/Program Files %28x86%29/.app/run.bat)"
+        ) in result
+
+    def test_no_special_chars_no_change(self):
         text = "[foo](#sensenova-claw-file:/sandbox/a.md)"
-        assert encode_file_link_parens(text) == text
+        assert sanitize_file_link_href(text) == text
 
     def test_multiple_file_links(self):
         text = (
             "[a](#sensenova-claw-file:a.md) 和 "
             "[b](#sensenova-claw-file:Files (x86)/b.md)"
         )
-        result = encode_file_link_parens(text)
+        result = sanitize_file_link_href(text)
         assert "[a](#sensenova-claw-file:a.md)" in result
         assert "[b](#sensenova-claw-file:Files %28x86%29/b.md)" in result
 
     def test_workdir_prefix_not_touched(self):
-        # 只编码 file 前缀，workdir 前缀维持原样
+        # 只处理 file 前缀，workdir 前缀维持原样（slide preview 用相对路径）
         text = "[slides](#sensenova-claw-workdir:my-ppt (draft)/page.html)"
-        assert encode_file_link_parens(text) == text
+        assert sanitize_file_link_href(text) == text
 
     def test_plain_link_not_touched(self):
         text = "参考 [wiki](https://en.wikipedia.org/wiki/Foo_(bar))"
-        assert encode_file_link_parens(text) == text
+        assert sanitize_file_link_href(text) == text
 
     def test_combined_with_rewrite(self):
-        """关键场景：含括号的 Windows 路径能完整走完 encode → rewrite 链路。"""
+        """含括号的 Windows 路径能完整走完 sanitize → rewrite 链路。"""
         text = "[报告](#sensenova-claw-file:Program Files (x86)/report.md)"
-        step1 = encode_file_link_parens(text)
+        step1 = sanitize_file_link_href(text)
         step2 = rewrite_file_link_hrefs(step1, "C:/sandbox")
         assert (
             "(#sensenova-claw-file:C:/sandbox/Program Files %28x86%29/report.md)"
             in step2
         )
 
+    def test_combined_windows_absolute_with_hidden_dir(self):
+        """真实线上场景回归：Windows 绝对路径 + 隐藏目录 \\.sensenova-claw。"""
+        text = (
+            "文件在 [a.md](#sensenova-claw-file:"
+            "C:\\Users\\zhengjieli1\\.sensenova-claw\\workdir\\default\\a.md)"
+        )
+        step1 = sanitize_file_link_href(text)
+        step2 = rewrite_file_link_hrefs(step1, "C:\\Users\\zhengjieli1\\.sensenova-claw\\workdir\\default")
+        # sanitize 后路径是正斜杠绝对，rewrite 判为绝对路径不再改动
+        assert (
+            "(#sensenova-claw-file:"
+            "C:/Users/zhengjieli1/.sensenova-claw/workdir/default/a.md)"
+        ) in step2
+
     def test_empty_content(self):
-        assert encode_file_link_parens("") == ""
+        assert sanitize_file_link_href("") == ""
 
 
 class TestRewriteRelativePathsWindows:


### PR DESCRIPTION
## Summary

  修复在 Windows 宿主下，LLM 输出的 `#sensenova-claw-file:` chip 点击后弹出
  "文件未找到" 的问题，并一并修复 `path_rewriter` 中与 Windows 路径相关的
  多处跨平台缺陷。

## 根因

  **CommonMark link destination 允许 backslash-escape**：`\` + ASCII 标点
  （`\.`、`\_`、`\-` 等）会被识别为转义序列，反斜杠被吃掉。
  - `\U`、`\z`、`\w`、`\d` → 字母非标点，保留
  - `\.` → `.`
  - 
## 修复

  ### `sensenova_claw/kernel/runtime/path_rewriter.py`

  - 新增 `sanitize_file_link_href(content)`：渲染前规避 markdown 对
    `#sensenova-claw-file:` href 的错误解析。把 body 里所有 `\` 换成 `/`
    (Windows Python `Path` 两种分隔符等价)，同时把未转义的 `(` `)`
    编码为 `%28` `%29`。
  - 新增 `_split_drive` / `_normalize_workdir` / `_join_and_normalize`：
    统一以字符串层面处理 Windows 盘符，不依赖宿主 `Path` 的平台行为；
    `..` 最多退到盘符根或 POSIX 根，**不再吞盘符**。
  - `_FILE_LINK_RE` 支持一层 `(...)` 平衡括号嵌套，覆盖 "Program Files (x86)" 这类路径。
  - `_looks_like_relative_file_path` 判断绝对路径改用 `_is_absolute_pathlike`，
    消除 POSIX/Windows `Path.is_absolute()` 的行为差异。
  - 旧的 `rewrite_file_link_hrefs` / `rewrite_relative_paths` 均走新辅助函数，
    保持两条链路在跨平台场景下的输出一致。

### `sensenova_claw/kernel/runtime/workers/agent_worker.py`

  在 `rewrite_relative_paths` / `rewrite_file_link_hrefs` 之前增加
  `sanitize_file_link_href`，顺序为 sanitize → relative rewrite → href rewrite。

  ### `sensenova_claw/app/web/components/ui/Markdown.tsx`

  给 file/workdir chip 的 `<a>` 加 `title={filePath|relPath}`，修复 hover
  时浏览器状态栏只显示 `#` 的 UX 问题，方便用户确认 chip 对应的真实路径。