### PR TITLE
添加日志记录并改进技能注册表中的元数据验证逻辑

### DIFF
--- a/sensenova_claw/capabilities/skills/registry.py
+++ b/sensenova_claw/capabilities/skills/registry.py
@@ -1,12 +1,16 @@
 from __future__ import annotations
 
 import json
+import logging
 import shutil
 import yaml
 from pathlib import Path
 from typing import Any
 
 from sensenova_claw.platform.config.workspace import default_sensenova_claw_home
+
+
+logger = logging.getLogger(__name__)
 
 
 class Skill:
@@ -232,8 +236,51 @@ class SkillRegistry:
     def _check_binary_deps(self, skill: Skill) -> bool:
         """检查 skill 所需的二进制依赖是否可用"""
         metadata = self._parse_metadata(skill)
-        requires = (metadata.get("sensenova-claw") or metadata.get("sensenova_claw") or {}).get("requires", {})
+        if not isinstance(metadata, dict):
+            logger.error(
+                "Skipping skill %s: metadata must be a mapping, got %s (%s)",
+                skill.name,
+                type(metadata).__name__,
+                skill.path / "SKILL.md",
+            )
+            return False
+
+        if "sensenova-claw" in metadata:
+            sensenova_metadata = metadata["sensenova-claw"]
+        elif "sensenova_claw" in metadata:
+            sensenova_metadata = metadata["sensenova_claw"]
+        else:
+            sensenova_metadata = {}
+
+        if not isinstance(sensenova_metadata, dict):
+            logger.error(
+                "Skipping skill %s: metadata.sensenova-claw must be a mapping, got %s (%s)",
+                skill.name,
+                type(sensenova_metadata).__name__,
+                skill.path / "SKILL.md",
+            )
+            return False
+
+        requires = sensenova_metadata.get("requires", {})
+        if not isinstance(requires, dict):
+            logger.error(
+                "Skipping skill %s: metadata.sensenova-claw.requires must be a mapping, got %s (%s)",
+                skill.name,
+                type(requires).__name__,
+                skill.path / "SKILL.md",
+            )
+            return False
+
         bins = requires.get("bins", [])
+        if not isinstance(bins, list):
+            logger.error(
+                "Skipping skill %s: metadata.sensenova-claw.requires.bins must be a list, got %s (%s)",
+                skill.name,
+                type(bins).__name__,
+                skill.path / "SKILL.md",
+            )
+            return False
+
         for bin_name in bins:
             if not shutil.which(bin_name):
                 return False

--- a/tests/unit/test_skill_registry.py
+++ b/tests/unit/test_skill_registry.py
@@ -1,5 +1,6 @@
 from pathlib import Path
 import tempfile
+import logging
 import pytest
 from sensenova_claw.capabilities.skills.registry import SkillRegistry
 
@@ -28,7 +29,7 @@ def test_load_skills():
         skill_dir.mkdir()
         (skill_dir / "SKILL.md").write_text("---\nname: skill1\ndescription: 技能1\n---\n内容1\n", encoding="utf-8")
 
-        registry = SkillRegistry(workspace_dir=Path(tmpdir))
+        registry = SkillRegistry(workspace_dir=Path(tmpdir), user_dir=Path(tmpdir) / "user-skills")
         registry.load_skills({})
 
         skills = registry.get_all()
@@ -44,10 +45,35 @@ def test_skill_disabled():
         (skill_dir / "SKILL.md").write_text("---\nname: skill1\ndescription: 技能1\n---\n内容\n", encoding="utf-8")
 
         config = {"skills": {"entries": {"skill1": {"enabled": False}}}}
-        registry = SkillRegistry(workspace_dir=Path(tmpdir))
+        registry = SkillRegistry(workspace_dir=Path(tmpdir), user_dir=Path(tmpdir) / "user-skills")
         registry.load_skills(config)
 
         assert len(registry.get_all()) == 0
+
+
+def test_load_skills_skips_malformed_sensenova_metadata(caplog):
+    """metadata.sensenova-claw 写错类型时跳过该 skill 但不影响启动"""
+    with tempfile.TemporaryDirectory() as tmpdir:
+        skill_dir = Path(tmpdir) / "skill1"
+        skill_dir.mkdir()
+        (skill_dir / "SKILL.md").write_text(
+            "---\n"
+            "name: skill1\n"
+            "description: 技能1\n"
+            "metadata:\n"
+            "  sensenova-claw: bad-metadata\n"
+            "---\n"
+            "内容\n",
+            encoding="utf-8",
+        )
+
+        registry = SkillRegistry(workspace_dir=Path(tmpdir), user_dir=Path(tmpdir) / "user-skills")
+        caplog.set_level(logging.ERROR)
+        registry.load_skills({})
+
+        assert registry.get("skill1") is None
+        assert "Skipping skill skill1" in caplog.text
+        assert "metadata.sensenova-claw must be a mapping" in caplog.text
 
 
 def test_workspace_overrides_user():


### PR DESCRIPTION
添加日志记录并改进技能注册表中的元数据验证逻辑，避免因为skill格式错误导致整个启动崩了。
当前逻辑：格式错误的skill抛出错误，不加载，启动正常进行