### PR TITLE
fix(llm): allow custom provider names in /llm-status check

### DIFF
--- a/sensenova_claw/platform/config/llm_presets.py
+++ b/sensenova_claw/platform/config/llm_presets.py
@@ -173,15 +173,14 @@ def check_llm_configured(config_data: dict, secret_store: Any | None = None) -> 
     llm_section = config_data.get("llm", {})
     providers_section = llm_section.get("providers", {})
 
-    # 遍历所有非 mock 提供商，检查 api_key 是否有效
-    all_provider_keys = {p["key"] for p in get_all_providers()}
-
+    # 遍历所有非 mock 提供商，检查 api_key 是否有效。
+    # 只要 provider 在 config 里有合法 api_key 就算"已配置"——不要求名字
+    # 必须出现在 LLM_PROVIDER_CATEGORIES 预设里，否则用户自定义的 provider 名
+    # （例如 SenseTime 内部的 `sensenova-v6_7-flash`）会被误判为未配置，
+    # 触发死循环重定向到 /setup。
     for provider_key, provider_cfg in providers_section.items():
         # 跳过 mock 提供商
         if provider_key == "mock":
-            continue
-        # 只检查预设中已知的提供商
-        if provider_key not in all_provider_keys:
             continue
         if not isinstance(provider_cfg, dict):
             continue


### PR DESCRIPTION
`check_llm_configured()` was filtering out any provider whose key wasn't in `LLM_PROVIDER_CATEGORIES` (openai/qwen/zhipu/minimax/deepseek/ custom_openai/anthropic/gemini). User-defined names — e.g. SenseTime internal `sensenova-v6_7-flash` configured by the wizard — were silently dropped, so /api/config/llm-status returned `{"configured": false}` and the dashboard's ProtectedRoute kept redirecting to /setup on every page load even though a working provider was already saved.

Drop the preset whitelist; any provider with a valid api_key counts.

Verified live by hot-patching the running VM and re-hitting the endpoint:
- before: {"configured":false,"providers":[]}
- after:  {"configured":true,"providers":["sensenova-v6_7-flash"]}